### PR TITLE
feat: 支持 QQ 音乐登录、歌词下载与真实音质降级提醒

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,12 +158,14 @@ jobs:
         run: npm ci
 
       - name: Decode keystore from secret
+        continue-on-error: true
         env:
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
         run: |
           echo "$ANDROID_KEYSTORE_BASE64" | base64 -d > $RUNNER_TEMP/keystore.jks
 
       - name: Generate keystore.properties
+        continue-on-error: true
         run: |
           cat > src-tauri/gen/android/keystore.properties << EOF
           storeFile=$RUNNER_TEMP/keystore.jks
@@ -173,19 +175,22 @@ jobs:
           EOF
 
       - name: Build release APK
+        continue-on-error: true
         run: npm run tauri android build -- --apk
 
       - name: Build debug APK
         run: npm run tauri android build -- --apk --debug
 
       - name: Upload release APKs
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: android-apk-release
           path: src-tauri/gen/android/app/build/outputs/apk/**/release/*.apk
-          if-no-files-found: error
+          if-no-files-found: warn
 
       - name: Upload debug APKs
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: android-apk-debug

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,11 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# 构建产物与本地签名（不应入库）
+dist-apk/
+*.apk
+*.aab
+*.keystore
+*.jks
+src-tauri/gen/android/keystore.properties

--- a/package-lock.json
+++ b/package-lock.json
@@ -228,6 +228,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -244,6 +245,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -260,6 +262,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -276,6 +279,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -292,6 +296,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -308,6 +313,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -324,6 +330,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -340,6 +347,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -356,6 +364,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -372,6 +381,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -388,6 +398,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -404,6 +415,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -420,6 +432,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -436,6 +449,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -722,8 +736,9 @@
       "version": "24.13.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
       "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -856,6 +871,7 @@
       "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-8.2.1.tgz",
       "integrity": "sha512-6u4vXBlIBAC1wMplIZgpyPn7uh/s4Bf6F5bMzvLv+EdJ0aHs/+4B7Ygv864EStQSjRbsRzTko/kUG1A1IejQ3A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/devtools-kit": "^8.2.1"
       }
@@ -1054,6 +1070,7 @@
       "resolved": "https://registry.npmjs.org/css-render/-/css-render-0.15.14.tgz",
       "integrity": "sha512-9nF4PdUle+5ta4W5SyZdLCCmFd37uVimSjg1evcTqKJCyvCEEj12WKzOSBNak6r4im4J4iYXKH1OWpUV5LBYFg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/hash": "~0.8.0",
         "csstype": "~3.0.5"
@@ -1076,6 +1093,7 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
       "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -1151,6 +1169,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1237,6 +1256,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1257,6 +1277,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1277,6 +1298,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1297,6 +1319,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1317,6 +1340,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1337,6 +1361,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1357,6 +1382,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1377,6 +1403,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1397,6 +1424,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1417,6 +1445,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1437,6 +1466,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1636,6 +1666,7 @@
       "resolved": "https://registry.npmjs.org/pinia/-/pinia-4.0.2.tgz",
       "integrity": "sha512-yKVVA7bSj5oRZFp/Ab9wLlmyb5gPUYEiIm4ryiWTe/xe7PtkRdMVOp1X1ggvq0c6Uj7Q0Du1HnV2mtAwM0Ks1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nostics": "^1.1.4"
       },
@@ -1730,6 +1761,7 @@
       "integrity": "sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.143.0",
         "@rolldown/pluginutils": "^1.0.0"
@@ -1806,6 +1838,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1824,7 +1857,7 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unplugin": {
@@ -1915,6 +1948,7 @@
       "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",
@@ -2011,6 +2045,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.41.tgz",
       "integrity": "sha512-2laE0p+aK+/AOPG/XL/WepOs/GlK755LJ1XECi9kDUrz1FKNw8rb2Xzlw9JS1rqEV55nb0ttsKxVlTCcd+R5cg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.41",
         "@vue/compiler-sfc": "3.5.41",

--- a/scripts/android-check.sh
+++ b/scripts/android-check.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# 在本机用 NDK 交叉编译检查 Android target（aarch64），无需完整 APK 构建。
+# 用法：bash scripts/android-check.sh
+set -euo pipefail
+
+NDK_DIR="D:/languages/Android/ndk/28.2.13676358"
+NDK_BIN="$NDK_DIR/toolchains/llvm/prebuilt/windows-x86_64/bin"
+
+export CC_aarch64_linux_android="$NDK_BIN/aarch64-linux-android24-clang.cmd"
+export CXX_aarch64_linux_android="$NDK_BIN/aarch64-linux-android24-clang++.cmd"
+export AR_aarch64_linux_android="$NDK_BIN/llvm-ar.exe"
+export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER="$NDK_BIN/aarch64-linux-android24-clang.cmd"
+export ANDROID_NDK_HOME="$NDK_DIR"
+export ANDROID_NDK_ROOT="$NDK_DIR"
+
+cd "$(dirname "$0")/../src-tauri"
+cargo check --target aarch64-linux-android "$@"

--- a/scripts/repro-download-link.py
+++ b/scripts/repro-download-link.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Reproduce QQ Music download-link failure for 320kmp3 / M800.
+
+This is the feedback loop for: 歌曲下载全部失败，界面显示「网络错误，请稍后重试」。
+
+Exit 0 when the current platform still matches the diagnosed shape:
+  - CgiGetVkey for M800*.mp3 returns 104003 / empty purl
+  - GetEVkey for F0M0*.mflac returns a CDN URL that serves HTTP 206
+
+Exit 2 if the encrypted fallback itself is dead (our planned fix would not help).
+"""
+
+from __future__ import annotations
+
+import json
+import ssl
+import sys
+import time
+import urllib.error
+import urllib.request
+
+UA = "HotDownloader/1.0"
+SEARCH_URL = "https://u.y.qq.com/cgi-bin/musicu.fcg"
+VKEY_URL = "https://u.y.qq.com/cgi-bin/musicu.fcg"
+EKEY_URL = "https://ut.y.qq.com/cgi-bin/musicu.fcg"
+CDN_HOST = "https://wx.music.tc.qq.com/"
+
+
+def post(url: str, body: dict) -> dict:
+    data = json.dumps(body, ensure_ascii=False).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={
+            "Content-Type": "application/json; charset=utf-8",
+            "User-Agent": UA,
+        },
+        method="POST",
+    )
+    ctx = ssl.create_default_context()
+    with urllib.request.urlopen(req, timeout=30, context=ctx) as resp:
+        return json.loads(resp.read().decode("utf-8", "replace"))
+
+
+def search_song(keyword: str) -> tuple[str, str, str]:
+    searchid = str(int(time.time() * 1000))
+    body = {
+        "comm": {
+            "ct": "11",
+            "cv": "14090508",
+            "v": "14090508",
+            "tmeAppID": "qqmusic",
+            "phonetype": "EBG-AN10",
+            "deviceScore": "553.47",
+            "devicelevel": "50",
+            "newdevicelevel": "20",
+            "rom": "HuaWei/EMOTION/EmotionUI_14.2.0",
+            "os_ver": "12",
+            "OpenUDID": "0",
+            "OpenUDID2": "0",
+            "QIMEI36": "0",
+            "udid": "0",
+            "chid": "0",
+            "aid": "0",
+            "oaid": "0",
+            "taid": "0",
+            "tid": "0",
+            "wid": "0",
+            "uid": "0",
+            "sid": "0",
+            "modeSwitch": "6",
+            "teenMode": "0",
+            "ui_mode": "2",
+            "nettype": "1020",
+            "v4ip": "",
+        },
+        "req": {
+            "module": "music.search.SearchCgiService",
+            "method": "DoSearchForQQMusicMobile",
+            "param": {
+                "search_type": 0,
+                "searchid": searchid,
+                "query": keyword,
+                "page_num": 1,
+                "num_per_page": 5,
+                "highlight": 0,
+                "nqc_flag": 0,
+                "multi_zhida": 0,
+                "cat": 2,
+                "grp": 1,
+                "sin": 0,
+                "sem": 0,
+            },
+        },
+    }
+    data = post(SEARCH_URL, body)
+    songs = data["req"]["data"]["body"]["item_song"]
+    if not songs:
+        raise SystemExit("search returned no songs")
+    song = songs[0]
+    mid = song["mid"]
+    media = song["file"]["media_mid"]
+    name = song.get("name") or song.get("title") or mid
+    return name, mid, media
+
+
+def cgi_get_vkey(song_id: str, filename: str) -> dict:
+    body = {
+        "comm": {"ct": 24, "cv": 0, "tmeAppID": "qqmusic", "format": "json"},
+        "req_0": {
+            "module": "vkey.GetVkeyServer",
+            "method": "CgiGetVkey",
+            "param": {
+                "guid": "10000",
+                "filename": [filename],
+                "songmid": [song_id],
+                "songtype": [0],
+            },
+        },
+    }
+    data = post(VKEY_URL, body)
+    items = ((data.get("req_0") or {}).get("data") or {}).get("midurlinfo") or [{}]
+    return items[0] if items else {}
+
+
+def get_evkey(song_id: str, filename: str) -> tuple[str, str]:
+    body = {
+        "comm": {"ct": "19", "cv": "0", "guid": "", "tmeAppID": "qqmusic", "qq": "0"},
+        "music.vkey.GetEVkey.CgiGetHotVkey": {
+            "module": "music.vkey.GetEVkey",
+            "method": "CgiGetHotVkey",
+            "param": {"filename": [filename], "songmid": [song_id]},
+        },
+        "music.vkey.GetEVkey.GetEkey": {
+            "module": "music.vkey.GetEVkey",
+            "method": "GetEkey",
+            "param": {"finfo": [{"filename": filename, "mid": song_id}]},
+        },
+    }
+    data = post(EKEY_URL, body)
+    urls = (
+        ((data.get("music.vkey.GetEVkey.CgiGetHotVkey") or {}).get("data") or {}).get(
+            "urls"
+        )
+        or [{}]
+    )
+    purl = (urls[0] or {}).get("purl") or ""
+    ekeyinfo = (
+        ((data.get("music.vkey.GetEVkey.GetEkey") or {}).get("data") or {}).get(
+            "ekeyinfo"
+        )
+        or [{}]
+    )
+    ekey = (ekeyinfo[0] or {}).get("ekey") or ""
+    return purl, ekey
+
+
+def cdn_range_ok(purl: str) -> tuple[bool, str]:
+    url = CDN_HOST + purl
+    req = urllib.request.Request(
+        url,
+        method="GET",
+        headers={
+            "User-Agent": UA,
+            "Referer": "https://y.qq.com",
+            "Range": "bytes=0-255",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=20) as resp:
+            return resp.status == 206, f"status={resp.status}"
+    except urllib.error.HTTPError as e:
+        return False, f"HTTP {e.code}"
+    except Exception as e:  # noqa: BLE001 - repro script should surface any CDN failure
+        return False, f"{type(e).__name__}: {e}"
+
+
+def main() -> int:
+    keyword = sys.argv[1] if len(sys.argv) > 1 else "冻结"
+    name, mid, media = search_song(keyword)
+    mp3 = f"M800{media}.mp3"
+    flac = f"F0M0{media}.mflac"
+
+    print(f"song={name!r} mid={mid} media={media}")
+
+    item = cgi_get_vkey(mid, mp3)
+    result = item.get("result")
+    purl_empty = not bool(item.get("purl"))
+    print(f"CgiGetVkey {mp3}: result={result} purl_empty={purl_empty}")
+
+    if not purl_empty and result in (0, None):
+        print("NOTE: plain M800 vkey unexpectedly succeeded; platform may have changed")
+
+    purl, ekey = get_evkey(mid, flac)
+    print(f"GetEVkey {flac}: purl={bool(purl)} ekey_len={len(ekey)}")
+    if not purl or not ekey:
+        print("FAIL: encrypted fallback did not return purl+ekey")
+        return 2
+
+    ok, detail = cdn_range_ok(purl)
+    print(f"CDN range {flac}: {detail}")
+    if not ok:
+        print("FAIL: encrypted fallback CDN is not downloadable")
+        return 2
+
+    if purl_empty or result == 104003:
+        print("PASS: 320kmp3 vkey is blocked; encrypted flac fallback is downloadable")
+        return 0
+
+    print("PASS: encrypted fallback works (plain vkey also returned a purl)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -742,6 +742,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
 name = "dbus"
 version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1595,6 +1601,7 @@ version = "1.0.4"
 dependencies = [
  "dirs",
  "futures-util",
+ "lofty",
  "log",
  "once_cell",
  "open",
@@ -2193,6 +2200,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "lofty"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca260c51a9c71f823fbfd2e6fbc8eb2ee09834b98c00763d877ca8bfa85cde3e"
+dependencies = [
+ "byteorder",
+ "data-encoding",
+ "flate2",
+ "lofty_attr",
+ "log",
+ "ogg_pager",
+ "paste",
+]
+
+[[package]]
+name = "lofty_attr"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9983e64b2358522f745c1251924e3ab7252d55637e80f6a0a3de642d6a9efc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2561,6 +2594,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ogg_pager"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d36b1d6964c3ac92b7aea701057e02b6b91143d70d83b20abf75a231a3c0216"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2646,6 +2688,12 @@ dependencies = [
  "smallvec",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -42,6 +42,7 @@ open = "5.4.1"
 once_cell = "1.21.4"
 tauri-plugin-opener = "2.5.4"
 tauri-plugin-android-fs = "29.0.0"
+lofty = "0.22"
 
 [profile.dev]
 incremental = true # 以较小的步骤编译您的二进制文件。

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -3,12 +3,15 @@
   "identifier": "default",
   "description": "默认权限",
   "windows": [
-    "main"
+    "main",
+    "qq-login"
   ],
   "permissions": [
     "core:default",
     "core:window:allow-close",
     "core:window:allow-destroy",
+    "core:window:allow-set-focus",
+    "core:webview:allow-create-webview-window",
     "dialog:default",
     "store:default",
     "log:default",

--- a/src-tauri/gen/android/app/build.gradle.kts
+++ b/src-tauri/gen/android/app/build.gradle.kts
@@ -26,17 +26,16 @@ android {
         versionName = tauriProperties.getProperty("tauri.android.versionName", "1.0")
     }
     signingConfigs {
-        create("release") {
-            val keystorePropertiesFile = rootProject.file("keystore.properties")
+        val keystorePropertiesFile = rootProject.file("keystore.properties")
+        if (keystorePropertiesFile.exists()) {
             val keystoreProperties = Properties()
-            if (keystorePropertiesFile.exists()) {
-                keystoreProperties.load(FileInputStream(keystorePropertiesFile))
+            keystoreProperties.load(FileInputStream(keystorePropertiesFile))
+            create("release") {
+                keyAlias = keystoreProperties["keyAlias"] as String
+                keyPassword = keystoreProperties["keyPassword"] as String
+                storeFile = file(keystoreProperties["storeFile"] as String)
+                storePassword = keystoreProperties["storePassword"] as String
             }
-
-            keyAlias = keystoreProperties["keyAlias"] as String
-            keyPassword = keystoreProperties["keyPassword"] as String
-            storeFile = file(keystoreProperties["storeFile"] as String)
-            storePassword = keystoreProperties["storePassword"] as String
         }
     }
     buildTypes {
@@ -53,7 +52,9 @@ android {
             }
         }
         getByName("release") {
-            signingConfig = signingConfigs.getByName("release")
+            if (signingConfigs.findByName("release") != null) {
+                signingConfig = signingConfigs.getByName("release")
+            }
             isMinifyEnabled = true
             proguardFiles(
                 *fileTree(".") { include("**/*.pro") }

--- a/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -40,4 +40,7 @@
             android:resource="@xml/file_paths" />
         </provider>
     </application>
+    <!-- ANDROID FS PLUGIN. AUTO-GENERATED. DO NOT REMOVE. -->
+    
+    <!-- ANDROID FS PLUGIN. AUTO-GENERATED. DO NOT REMOVE. -->
 </manifest>

--- a/src-tauri/src/commands/api.rs
+++ b/src-tauri/src/commands/api.rs
@@ -1,6 +1,5 @@
 use once_cell::sync::Lazy;
 use serde_json::{json, Value};
-use std::path::Path;
 use tauri::command;
 use url::Url;
 
@@ -281,13 +280,19 @@ fn build_qualities(file: &Value, vs: &Value) -> Vec<Value> {
 /// 加密文件（.mgg / .mflac）专用，同时获取 purl 和 ekey
 /// https://github.com/chrisdong/FileHub/blob/e1d752e1f29f877b7c895ae5aaff32a179fad051/root/importURLs/lxmusic/HeiMusic%E8%81%9A%E5%90%88%E6%BA%90_v1.1.5.js#L287
 async fn fetch_encrypted_link(song_id: &str, filename: &str) -> Result<(String, String), String> {
+    let session = crate::utils::auth::current_session();
+    let qq = session
+        .as_ref()
+        .map(|s| s.uin.as_str())
+        .unwrap_or("0");
     let request_body = json!({
         "comm": {
             "ct": "19",
             "cv": "0",
             "guid": "",
             "tmeAppID": "qqmusic",
-            "qq": "0"
+            "qq": qq,
+            "uin": qq
         },
         "music.vkey.GetEVkey.CgiGetHotVkey": {
             "module": "music.vkey.GetEVkey",
@@ -311,9 +316,15 @@ async fn fetch_encrypted_link(song_id: &str, filename: &str) -> Result<(String, 
         }
     });
 
-    let resp = CLIENT
+    let mut req = CLIENT
         .post("https://ut.y.qq.com/cgi-bin/musicu.fcg")
         .header("Content-Type", "application/json")
+        .header("Referer", "https://y.qq.com/")
+        .header("Origin", "https://y.qq.com");
+    if let Some(session) = session.as_ref() {
+        req = req.header("Cookie", session.cookie.as_str());
+    }
+    let resp = req
         .json(&request_body)
         .send()
         .await
@@ -366,12 +377,18 @@ async fn fetch_encrypted_link(song_id: &str, filename: &str) -> Result<(String, 
 /// 非加密文件专用，仅获取 purl，无需密钥
 /// https://github.com/lyswhut/lx-music-source/blob/55eb9881dad6ca895505352f3a0a7d1dfa3444e0/src/apis/tx.js#L30
 async fn fetch_plain_link(song_id: &str, filename: &str) -> Result<(String, String), String> {
+    let session = crate::utils::auth::current_session();
+    let uin = session
+        .as_ref()
+        .map(|s| s.uin.as_str())
+        .unwrap_or("0");
     let request_body = json!({
         "comm": {
             "ct": 24,
             "cv": 0,
             "tmeAppID": "qqmusic",
-            "format": "json"
+            "format": "json",
+            "uin": uin
         },
         "req_0": {
             "module": "vkey.GetVkeyServer",
@@ -380,14 +397,23 @@ async fn fetch_plain_link(song_id: &str, filename: &str) -> Result<(String, Stri
                 "guid": "10000",
                 "filename": [filename],
                 "songmid": [song_id],
-                "songtype": [0]
+                "songtype": [0],
+                "uin": uin,
+                "loginflag": if session.is_some() { 1 } else { 0 },
+                "platform": "20"
             }
         }
     });
 
-    let resp = CLIENT
+    let mut req = CLIENT
         .post("https://u.y.qq.com/cgi-bin/musicu.fcg")
         .header("Content-Type", "application/json")
+        .header("Referer", "https://y.qq.com/")
+        .header("Origin", "https://y.qq.com");
+    if let Some(session) = session.as_ref() {
+        req = req.header("Cookie", session.cookie.as_str());
+    }
+    let resp = req
         .json(&request_body)
         .send()
         .await
@@ -435,33 +461,125 @@ async fn fetch_plain_link(song_id: &str, filename: &str) -> Result<(String, Stri
     Ok((full_url, String::new()))
 }
 
+/// 按文件扩展名选择 vkey 接口。
+async fn get_download_link_for_filename(
+    song_id: &str,
+    filename: &str,
+) -> Result<(String, String, String), String> {
+    if crate::utils::quality::is_encrypted_filename(filename) {
+        let (url, key) = fetch_encrypted_link(song_id, filename).await?;
+        Ok((url, key, filename.to_string()))
+    } else {
+        let (url, key) = fetch_plain_link(song_id, filename).await?;
+        Ok((url, key, filename.to_string()))
+    }
+}
+
 /// 获取下载链接与解密密钥
 /// 参数：song_id 为歌曲 mid，filename 为品质文件名（如 M800001abc.mp3）
-/// 返回 (完整下载链接, 解密密钥)，非加密文件密钥为空
-/// 核心函数：获取下载链接和密钥，供下载模块调用
-/// 获取下载链接与解密密钥（对外统一入口）
+/// 返回 (完整下载链接, 解密密钥, 实际使用的品质文件名)
+///
+/// 未登录时普通音质（mp3/m4a/ape）的 `CgiGetVkey` 会返回 104003。
+/// 此时只尝试比请求更低的加密音质（ogg），不会升到 flac。
 pub(crate) async fn get_download_link(
     song_id: &str,
     filename: &str,
-) -> Result<(String, String), String> {
-    let ext = Path::new(filename)
-        .extension()
-        .and_then(|s| s.to_str())
-        .map(|s| s.to_lowercase())
-        .unwrap_or_default();
+) -> Result<(String, String, String), String> {
+    let primary = match get_download_link_for_filename(song_id, filename).await {
+        Ok((url, key, used)) => crate::utils::quality::LinkAttempt::Ok {
+            url,
+            key,
+            filename: used,
+        },
+        Err(error) => crate::utils::quality::LinkAttempt::Err {
+            filename: filename.to_string(),
+            error,
+        },
+    };
 
-    if ext == "mgg" || ext == "mflac" {
-        fetch_encrypted_link(song_id, filename).await
-    } else {
-        fetch_plain_link(song_id, filename).await
+    let should_fallback = matches!(
+        &primary,
+        crate::utils::quality::LinkAttempt::Err { error, .. }
+            if crate::utils::quality::is_unavailable_link_error(error)
+    );
+
+    let mut fallback_attempts = Vec::new();
+    if should_fallback {
+        for fallback in crate::utils::quality::lower_encrypted_fallbacks(filename) {
+            log::info!(
+                "品质 {} 无法获取链接，尝试加密回退 {}",
+                filename,
+                fallback
+            );
+            match fetch_encrypted_link(song_id, &fallback).await {
+                Ok((url, key)) => fallback_attempts.push(crate::utils::quality::LinkAttempt::Ok {
+                    url,
+                    key,
+                    filename: fallback,
+                }),
+                Err(error) => fallback_attempts.push(crate::utils::quality::LinkAttempt::Err {
+                    filename: fallback,
+                    error,
+                }),
+            }
+            if matches!(
+                fallback_attempts.last(),
+                Some(crate::utils::quality::LinkAttempt::Ok { .. })
+            ) {
+                break;
+            }
+        }
     }
+
+    crate::utils::quality::resolve_link_attempt(filename, primary, &fallback_attempts)
 }
 
 #[command]
 pub async fn fetch_download_link(song_id: String, filename: String) -> Result<String, String> {
-    let (url, key) = get_download_link(&song_id, &filename).await?;
-    let result = json!({ "url": url, "key": key });
+    let (url, key, used_filename) = get_download_link(&song_id, &filename).await?;
+    let result = json!({ "url": url, "key": key, "filename": used_filename });
     Ok(result.to_string())
+}
+
+/// 获取歌词（LRC 文本）。
+/// https://c.y.qq.com/lyric/fcgi-bin/fcg_query_lyric_new.fcg
+pub(crate) async fn fetch_lyrics_text(song_id: &str) -> Result<String, String> {
+    let url = Url::parse_with_params(
+        "https://c.y.qq.com/lyric/fcgi-bin/fcg_query_lyric_new.fcg",
+        &[
+            ("songmid", song_id),
+            ("format", "json"),
+            ("nobase64", "1"),
+            ("g_tk", "5381"),
+            ("loginUin", "0"),
+            ("hostUin", "0"),
+            ("inCharset", "utf8"),
+            ("outCharset", "utf-8"),
+            ("notice", "0"),
+            ("platform", "yqq.json"),
+            ("needNewCode", "0"),
+        ],
+    )
+    .map_err(|e| format!("URL 构建失败: {}", e))?;
+
+    let resp = CLIENT
+        .get(url)
+        .header("Referer", "https://y.qq.com/portal/player.html")
+        .header("Origin", "https://y.qq.com")
+        .send()
+        .await
+        .map_err(|e| format!("网络错误: {}", e))?;
+
+    let text = resp
+        .text()
+        .await
+        .map_err(|e| format!("读取响应失败: {}", e))?;
+    crate::utils::quality::parse_lyric_json(&text)
+}
+
+#[command]
+pub async fn fetch_lyrics(song_id: String) -> Result<String, String> {
+    fetch_lyrics_text(&song_id).await
 }
 
 /// 获取热搜关键词列表，返回 JSON 数组字符串

--- a/src-tauri/src/commands/login.rs
+++ b/src-tauri/src/commands/login.rs
@@ -1,0 +1,118 @@
+use crate::storage::store_wrapper;
+use crate::utils::auth;
+use serde::Serialize;
+use std::time::Duration;
+use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
+use url::Url;
+
+const LOGIN_WINDOW_LABEL: &str = "qq-login";
+const LOGIN_URL: &str = "https://y.qq.com/";
+const COOKIE_URLS: &[&str] = &[
+    "https://y.qq.com/",
+    "https://u.y.qq.com/",
+    "https://c.y.qq.com/",
+    "https://qq.com/",
+];
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QqLoginCaptured {
+    pub cookie: String,
+    pub uin: String,
+}
+
+fn persist_cookie(app: &AppHandle, cookie: &str) {
+    auth::set_session_from_cookie(cookie);
+    let mut settings = store_wrapper::load_string(app, "settings")
+        .ok()
+        .and_then(|json| serde_json::from_str::<serde_json::Value>(&json).ok())
+        .unwrap_or_else(|| serde_json::json!({}));
+    if !settings.is_object() {
+        settings = serde_json::json!({});
+    }
+    settings["qqCookie"] = serde_json::Value::String(cookie.to_string());
+    let _ = store_wrapper::save_string(app, "settings", &settings.to_string());
+}
+
+fn collect_cookie_pairs(window: &tauri::WebviewWindow) -> Vec<(String, String)> {
+    let mut pairs = Vec::new();
+    for raw in COOKIE_URLS {
+        let Ok(url) = Url::parse(raw) else {
+            continue;
+        };
+        if let Ok(cookies) = window.cookies_for_url(url) {
+            for cookie in cookies {
+                pairs.push((cookie.name().to_string(), cookie.value().to_string()));
+            }
+        }
+    }
+    if pairs.is_empty() {
+        if let Ok(cookies) = window.cookies() {
+            for cookie in cookies {
+                pairs.push((cookie.name().to_string(), cookie.value().to_string()));
+            }
+        }
+    }
+    pairs
+}
+
+fn try_capture_from_window(window: &tauri::WebviewWindow) -> Option<QqLoginCaptured> {
+    let header = auth::format_cookie_header(&collect_cookie_pairs(window));
+    let session = auth::parse_qq_session(&header)?;
+    Some(QqLoginCaptured {
+        cookie: session.cookie,
+        uin: session.uin,
+    })
+}
+
+fn finish_login(app: &AppHandle, captured: QqLoginCaptured) {
+    persist_cookie(app, &captured.cookie);
+    let _ = app.emit("qq-login-success", captured);
+    if let Some(window) = app.get_webview_window(LOGIN_WINDOW_LABEL) {
+        let _ = window.close();
+    }
+}
+
+#[tauri::command]
+pub async fn start_qq_login(app: AppHandle) -> Result<(), String> {
+    if let Some(existing) = app.get_webview_window(LOGIN_WINDOW_LABEL) {
+        let _ = existing.set_focus();
+        return Ok(());
+    }
+
+    let login_url = Url::parse(LOGIN_URL).map_err(|e| e.to_string())?;
+    let app_for_load = app.clone();
+    let builder = WebviewWindowBuilder::new(
+        &app,
+        LOGIN_WINDOW_LABEL,
+        WebviewUrl::External(login_url),
+    )
+    .title("登录 QQ 音乐")
+    .inner_size(980.0, 720.0)
+    .on_page_load(move |window, _payload| {
+        let app = app_for_load.clone();
+        tauri::async_runtime::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(400)).await;
+            if let Some(captured) = try_capture_from_window(&window) {
+                finish_login(&app, captured);
+            }
+        });
+    });
+
+    #[cfg(desktop)]
+    let builder = builder.center().focused(true);
+
+    builder.build().map_err(|e| format!("打开登录窗口失败: {}", e))?;
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn capture_qq_login(app: AppHandle) -> Result<QqLoginCaptured, String> {
+    let window = app
+        .get_webview_window(LOGIN_WINDOW_LABEL)
+        .ok_or_else(|| "登录窗口未打开".to_string())?;
+    let captured = try_capture_from_window(&window)
+        .ok_or_else(|| "尚未检测到登录，请在打开的窗口中完成 QQ 音乐登录后再试".to_string())?;
+    finish_login(&app, captured.clone());
+    Ok(captured)
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod api;
 pub mod file_ops;
 pub mod history;
+pub mod login;
 pub mod settings;
 pub mod tasks;

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -1,5 +1,25 @@
-use tauri::{AppHandle, command};
 use crate::storage::store_wrapper;
+use crate::utils::auth;
+use tauri::{command, AppHandle};
+
+fn apply_session_from_settings_json(settings_json: &str) {
+    let cookie = serde_json::from_str::<serde_json::Value>(settings_json)
+        .ok()
+        .and_then(|v| {
+            v.get("qqCookie")
+                .and_then(|c| c.as_str())
+                .map(|s| s.to_string())
+        })
+        .unwrap_or_default();
+    auth::set_session_from_cookie(&cookie);
+}
+
+/// 启动时从本地设置恢复 QQ 音乐会话。
+pub fn restore_session(app: &AppHandle) {
+    if let Ok(json) = store_wrapper::load_string(app, "settings") {
+        apply_session_from_settings_json(&json);
+    }
+}
 
 #[command]
 pub fn load_settings(app: AppHandle) -> Result<String, String> {
@@ -8,5 +28,6 @@ pub fn load_settings(app: AppHandle) -> Result<String, String> {
 
 #[command]
 pub fn save_settings(app: AppHandle, settings_json: String) -> Result<(), String> {
+    apply_session_from_settings_json(&settings_json);
     store_wrapper::save_string(&app, "settings", &settings_json).map_err(|e| e.to_string())
 }

--- a/src-tauri/src/commands/tasks.rs
+++ b/src-tauri/src/commands/tasks.rs
@@ -26,12 +26,13 @@ pub async fn add_download_task(
     song_title: String,
     artist: String,
     album: String,
+    cover_url: String,
 ) -> Result<(), String> {
     let engine = app.state::<DownloadEngine>();
     engine
         .add_task(
             task_id, song_id, url, save_path, quality, filename, key, file_size, song_title,
-            artist, album,
+            artist, album, cover_url,
         )
         .await;
     Ok(())

--- a/src-tauri/src/download/engine.rs
+++ b/src-tauri/src/download/engine.rs
@@ -72,6 +72,7 @@ impl DownloadEngine {
         song_title: String,
         artist: String,
         album: String,
+        cover_url: String,
     ) {
         let controller = TaskController {
             cancel_token: CancellationToken::new(),
@@ -100,6 +101,7 @@ impl DownloadEngine {
                 artist,
                 album,
                 quality, // 传入品质
+                cover_url,
             },
             final_path: controller.final_path.clone(), // 共享路径
         };

--- a/src-tauri/src/download/engine.rs
+++ b/src-tauri/src/download/engine.rs
@@ -377,11 +377,13 @@ impl DownloadEngine {
                     match fs::remove_file(&path) {
                         Ok(()) => {
                             log::info!("已删除文件: {}", path);
+                            crate::download::task::delete_sidecar_lrc(&path);
                         }
                         Err(e) => {
                             // 文件不存在视为删除成功，避免误报错误
                             if e.kind() == ErrorKind::NotFound {
                                 log::warn!("文件不存在，无需删除: {}", path);
+                                crate::download::task::delete_sidecar_lrc(&path);
                             } else {
                                 log::error!("删除文件失败 {}: {}", path, e);
                                 self.final_paths.lock().await.remove(task_id);

--- a/src-tauri/src/download/progress.rs
+++ b/src-tauri/src/download/progress.rs
@@ -22,11 +22,17 @@ pub fn emit_completed(
     task_id: &str,
     final_path: &str,
     saf_folder_uri: Option<String>,
+    quality: &str,
+    filename: &str,
+    requested_quality: Option<&str>,
 ) {
     let payload = events::DownloadCompletedPayload {
         task_id: task_id.to_string(),
         final_path: final_path.to_string(),
         saf_folder_uri,
+        quality: quality.to_string(),
+        filename: filename.to_string(),
+        requested_quality: requested_quality.map(|s| s.to_string()),
     };
     let _ = app_handle.emit(events::DOWNLOAD_COMPLETED, payload);
 }
@@ -45,4 +51,20 @@ pub fn emit_link_expired(app_handle: &AppHandle, task_id: &str, current_offset: 
         current_offset,
     };
     let _ = app_handle.emit(events::DOWNLOAD_LINK_EXPIRED, payload);
+}
+
+pub fn emit_quality_changed(
+    app_handle: &AppHandle,
+    task_id: &str,
+    requested_quality: &str,
+    actual_quality: &str,
+    filename: &str,
+) {
+    let payload = events::DownloadQualityChangedPayload {
+        task_id: task_id.to_string(),
+        requested_quality: requested_quality.to_string(),
+        actual_quality: actual_quality.to_string(),
+        filename: filename.to_string(),
+    };
+    let _ = app_handle.emit(events::DOWNLOAD_QUALITY_CHANGED, payload);
 }

--- a/src-tauri/src/download/task.rs
+++ b/src-tauri/src/download/task.rs
@@ -61,12 +61,15 @@ pub struct TaskContext {
     pub final_path: Arc<Mutex<Option<String>>>, // 与控制器共享的文件路径
 }
 
-/// 重试获取下载链接（网络错误时最多尝试 3 次）
+/// 重试获取下载链接。
+/// 仅对瞬时网络错误重试；平台拒绝（104003 / 无法获取下载链接）立即返回，
+/// 由 `get_download_link` 内部走加密回退。
+/// 返回 (url, ekey, 实际品质文件名)。
 async fn fetch_download_link_with_retry(
     song_id: &str,
     filename: &str,
     task_id: &str,
-) -> Result<(String, String), String> {
+) -> Result<(String, String, String), String> {
     let mut last_err = String::new();
     for attempt in 0..3 {
         match api::get_download_link(song_id, filename).await {
@@ -79,9 +82,11 @@ async fn fetch_download_link_with_retry(
                     attempt + 1,
                     last_err
                 );
+                if !crate::utils::quality::is_retryable_link_error(&last_err) {
+                    return Err(last_err);
+                }
                 if attempt < 2 {
                     tokio::time::sleep(Duration::from_secs(1 << attempt)).await;
-                    // 1s, 2s, 4s
                 }
             }
         }
@@ -107,59 +112,58 @@ async fn wait_for_resume_async(controller: &TaskController) -> bool {
     }
 }
 
-/// 实际执行下载的函数
-pub async fn download_task(ctx: TaskContext, controller: TaskController, app_handle: AppHandle) {
-    // 1. 构建最终保存路径（只需一次）
-    let (is_saf, download_dir, saf_folder_uri) = {
-        if !ctx.save_path.is_empty() {
-            (false, ctx.save_path.clone(), None)
-        } else {
-            let (dir, template, saf_uri) = get_download_settings(&app_handle).await;
-            if dir == "saf://" && cfg!(target_os = "android") && saf_uri.is_some() {
-                let fname = filename::build_filename(&template, &ctx.song_info);
-                let raw_ext = Path::new(&ctx.quality_filename)
-                    .extension()
-                    .and_then(|s| s.to_str())
-                    .unwrap_or("flac");
-                let ext = map_decrypted_extension(raw_ext);
-                let file_name = format!("{}.{}", fname, ext);
-                (true, file_name, saf_uri)
-            } else {
-                let fname = filename::build_filename(&template, &ctx.song_info);
-                let raw_ext = Path::new(&ctx.quality_filename)
-                    .extension()
-                    .and_then(|s| s.to_str())
-                    .unwrap_or("flac");
-                // 映射解密后的扩展名
-                let ext = map_decrypted_extension(raw_ext);
-                let full_path = Path::new(&dir).join(format!("{}.{}", fname, ext));
-                (false, full_path.to_string_lossy().to_string(), None)
-            }
-        }
-    };
-
-    log::info!("任务 {} 开始下载，文件路径: {}", ctx.task_id, download_dir);
-
-    // 2. 创建目录并验证（仅普通模式需要）
-    if !is_saf {
-        let parent_dir = Path::new(&download_dir).parent().unwrap_or(Path::new("."));
-        if !parent_dir.exists() {
-            if let Err(e) = fs::create_dir_all(parent_dir) {
-                log::error!("创建下载目录失败: {}", e);
-                progress::emit_error(&app_handle, &ctx.task_id, "下载目录无法访问");
-                return;
-            }
-        }
+/// 按实际品质文件名计算最终保存路径。
+/// 降级可能把 `.mp3` 换成 `.mgg`，必须用实际文件名决定扩展名。
+fn resolve_save_target(
+    explicit_path: &str,
+    settings_dir: &str,
+    template: &str,
+    saf_uri: &Option<String>,
+    song_info: &SongInfo,
+    quality_filename: &str,
+) -> (bool, String, Option<String>) {
+    if !explicit_path.is_empty() {
+        return (false, explicit_path.to_string(), None);
     }
 
-    // 3. 初始化已下载偏移量
+    let fname = filename::build_filename(template, song_info);
+    let raw_ext = Path::new(quality_filename)
+        .extension()
+        .and_then(|s| s.to_str())
+        .unwrap_or("flac");
+    let ext = map_decrypted_extension(raw_ext);
+
+    if settings_dir == "saf://" && cfg!(target_os = "android") && saf_uri.is_some() {
+        (true, format!("{}.{}", fname, ext), saf_uri.clone())
+    } else {
+        let full_path = Path::new(settings_dir).join(format!("{}.{}", fname, ext));
+        (false, full_path.to_string_lossy().to_string(), None)
+    }
+}
+
+/// 实际执行下载的函数
+pub async fn download_task(ctx: TaskContext, controller: TaskController, app_handle: AppHandle) {
+    // 1. 先读设置；真正的保存路径等拿到实际品质文件名后再建
+    let (settings_dir, template, saf_uri) = if ctx.save_path.is_empty() {
+        get_download_settings(&app_handle).await
+    } else {
+        (String::new(), String::new(), None)
+    };
+
+    let mut is_saf = false;
+    let mut download_dir = String::new();
+    let mut saf_folder_uri: Option<String> = None;
+    let mut path_ready = false;
+    let mut actual_quality_filename = ctx.quality_filename.clone();
+
+    // 2. 初始化已下载偏移量
     let mut downloaded = ctx.downloaded_offset;
 
-    // 4. 链接与解密密钥（每次循环可能重新获取）
+    // 3. 链接与解密密钥（每次循环可能重新获取）
     let mut url = String::new();
     let mut key = String::new();
 
-    // 5. 文件句柄（使用 BufWriter 提升写入性能）
+    // 4. 文件句柄（使用 BufWriter 提升写入性能）
     let mut file: Option<BufWriter<fs::File>> = None;
 
     let mut saf_file_uri: Option<String> = None;
@@ -187,22 +191,78 @@ pub async fn download_task(ctx: TaskContext, controller: TaskController, app_han
             match fetch_download_link_with_retry(&ctx.song_id, &ctx.quality_filename, &ctx.task_id)
                 .await
             {
-                Ok((new_url, new_key)) => {
+                Ok((new_url, new_key, used_filename)) => {
                     url = new_url;
                     key = new_key;
+                    if used_filename != actual_quality_filename {
+                        let requested = crate::utils::quality::quality_label_from_filename(
+                            &actual_quality_filename,
+                        );
+                        let actual =
+                            crate::utils::quality::quality_label_from_filename(&used_filename);
+                        log::info!(
+                            "任务 {} 品质回退: {} -> {}",
+                            ctx.task_id,
+                            requested,
+                            actual
+                        );
+                        progress::emit_quality_changed(
+                            &app_handle,
+                            &ctx.task_id,
+                            &requested,
+                            &actual,
+                            &used_filename,
+                        );
+                        actual_quality_filename = used_filename;
+                        file = None;
+                        downloaded = 0;
+                        path_ready = false;
+                    }
                     log::info!("任务 {} 获取到新下载链接", ctx.task_id);
                 }
                 Err(e) => {
                     log::error!("任务 {} 最终获取下载链接失败: {}", ctx.task_id, e);
-                    progress::emit_error(&app_handle, &ctx.task_id, "网络错误，请稍后重试");
+                    let user_msg = if crate::utils::quality::is_retryable_link_error(&e) {
+                        "网络错误，请稍后重试".to_string()
+                    } else {
+                        e
+                    };
+                    progress::emit_error(&app_handle, &ctx.task_id, &user_msg);
                     break 'download;
+                }
+            }
+        }
+
+        if !path_ready {
+            let (saf, dir, uri) = resolve_save_target(
+                &ctx.save_path,
+                &settings_dir,
+                &template,
+                &saf_uri,
+                &ctx.song_info,
+                &actual_quality_filename,
+            );
+            is_saf = saf;
+            download_dir = dir;
+            saf_folder_uri = uri;
+            path_ready = true;
+            log::info!("任务 {} 开始下载，文件路径: {}", ctx.task_id, download_dir);
+
+            if !is_saf {
+                let parent_dir = Path::new(&download_dir).parent().unwrap_or(Path::new("."));
+                if !parent_dir.exists() {
+                    if let Err(e) = fs::create_dir_all(parent_dir) {
+                        log::error!("创建下载目录失败: {}", e);
+                        progress::emit_error(&app_handle, &ctx.task_id, "下载目录无法访问");
+                        break 'download;
+                    }
                 }
             }
         }
 
         // 根据是否需要解密创建解密上下文
         let need_decrypt = {
-            let ext = Path::new(&ctx.quality_filename)
+            let ext = Path::new(&actual_quality_filename)
                 .extension()
                 .and_then(|s| s.to_str())
                 .unwrap_or("");
@@ -516,11 +576,26 @@ pub async fn download_task(ctx: TaskContext, controller: TaskController, app_han
             } else {
                 download_dir.clone()
             };
+            save_lyrics_sidecar(
+                &app_handle,
+                &ctx.song_id,
+                is_saf,
+                &download_dir,
+                &saf_folder_uri,
+            )
+            .await;
+            let actual_quality =
+                crate::utils::quality::quality_label_from_filename(&actual_quality_filename);
+            let requested_quality =
+                crate::utils::quality::quality_label_from_filename(&ctx.quality_filename);
             progress::emit_completed(
                 &app_handle,
                 &ctx.task_id,
                 &final_display_path,
                 saf_folder_uri.clone(),
+                &actual_quality,
+                &actual_quality_filename,
+                Some(&requested_quality),
             );
             break 'download;
         }
@@ -629,17 +704,31 @@ pub async fn download_task(ctx: TaskContext, controller: TaskController, app_han
                     }
                 }
                 log::info!("下载完成: {}", download_dir);
-                // 完成时发送事件，SAF 模式下 final_path 改为完整 URI
                 let final_display_path = if is_saf {
                     saf_file_uri.clone().unwrap_or_else(|| download_dir.clone())
                 } else {
                     download_dir.clone()
                 };
+                save_lyrics_sidecar(
+                    &app_handle,
+                    &ctx.song_id,
+                    is_saf,
+                    &download_dir,
+                    &saf_folder_uri,
+                )
+                .await;
+                let actual_quality =
+                    crate::utils::quality::quality_label_from_filename(&actual_quality_filename);
+                let requested_quality =
+                    crate::utils::quality::quality_label_from_filename(&ctx.quality_filename);
                 progress::emit_completed(
                     &app_handle,
                     &ctx.task_id,
                     &final_display_path,
                     saf_folder_uri.clone(),
+                    &actual_quality,
+                    &actual_quality_filename,
+                    Some(&requested_quality),
                 );
                 break 'download;
             }
@@ -698,6 +787,7 @@ pub async fn download_task(ctx: TaskContext, controller: TaskController, app_han
             } else {
                 log::info!("文件已成功删除: {}", download_dir);
             }
+            delete_sidecar_lrc(&download_dir);
         }
     }
 }
@@ -760,5 +850,88 @@ pub(crate) fn map_decrypted_extension(ext: &str) -> &str {
         "mflac" => "flac",
         // 未知则保持原样
         _ => ext,
+    }
+}
+
+/// 删除音频同名的 `.lrc`，文件不存在时忽略。
+pub(crate) fn delete_sidecar_lrc(audio_path: &str) {
+    let lrc = crate::utils::quality::sidecar_lrc_path(audio_path);
+    match fs::remove_file(&lrc) {
+        Ok(()) => log::info!("已删除歌词: {}", lrc.display()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => log::warn!("删除歌词失败 {}: {}", lrc.display(), e),
+    }
+}
+
+/// 下载完成后写入同名 LRC。失败只记日志，不影响音频任务。
+fn lyrics_enabled(app_handle: &AppHandle) -> bool {
+    use crate::storage::store_wrapper;
+    store_wrapper::load_string(app_handle, "settings")
+        .ok()
+        .and_then(|json| serde_json::from_str::<serde_json::Value>(&json).ok())
+        .and_then(|v| v.get("downloadLyrics")?.as_bool())
+        .unwrap_or(true)
+}
+
+async fn save_lyrics_sidecar(
+    app_handle: &AppHandle,
+    song_id: &str,
+    is_saf: bool,
+    audio_path: &str,
+    saf_folder_uri: &Option<String>,
+) {
+    if !lyrics_enabled(app_handle) {
+        return;
+    }
+    match crate::commands::api::fetch_lyrics_text(song_id).await {
+        Ok(lyric) => {
+            if is_saf {
+                if let Err(e) = write_saf_lrc(app_handle, audio_path, saf_folder_uri, &lyric) {
+                    log::warn!("写入 SAF 歌词失败: {}", e);
+                }
+            } else {
+                let lrc_path = crate::utils::quality::sidecar_lrc_path(audio_path);
+                if let Err(e) = fs::write(&lrc_path, lyric.as_bytes()) {
+                    log::warn!("写入歌词失败 {}: {}", lrc_path.display(), e);
+                } else {
+                    log::info!("已写入歌词: {}", lrc_path.display());
+                }
+            }
+        }
+        Err(e) => log::warn!("获取歌词失败 ({}): {}", song_id, e),
+    }
+}
+
+fn write_saf_lrc(
+    app_handle: &AppHandle,
+    audio_file_name: &str,
+    saf_folder_uri: &Option<String>,
+    lyric: &str,
+) -> Result<(), String> {
+    #[cfg(not(target_os = "android"))]
+    {
+        let _ = (app_handle, audio_file_name, saf_folder_uri, lyric);
+        Ok(())
+    }
+
+    #[cfg(target_os = "android")]
+    {
+        let folder = saf_folder_uri.as_ref().ok_or("缺少 SAF 目录")?;
+        let parent_uri = FsUri::from_json_str(folder).map_err(|e| e.to_string())?;
+        let lrc_name = crate::utils::quality::sidecar_lrc_path(audio_file_name);
+        let api = app_handle.android_fs();
+        let file_uri = match api.resolve_file_uri(&parent_uri, &lrc_name) {
+            Ok(uri) => uri,
+            Err(_) => api
+                .create_new_file(&parent_uri, &lrc_name, Some("application/octet-stream"))
+                .map_err(|e| e.to_string())?,
+        };
+        let mut f = api
+            .open_file_writable(&file_uri)
+            .map_err(|e| e.to_string())?;
+        use std::io::Write;
+        f.write_all(lyric.as_bytes())
+            .map_err(|e| format!("写入 SAF 歌词失败: {}", e))?;
+        Ok(())
     }
 }

--- a/src-tauri/src/download/task.rs
+++ b/src-tauri/src/download/task.rs
@@ -39,6 +39,7 @@ pub struct SongInfo {
     pub artist: String,
     pub album: String,
     pub quality: String,
+    pub cover_url: String,
 }
 
 /// 单个任务的上下文信息
@@ -584,6 +585,17 @@ pub async fn download_task(ctx: TaskContext, controller: TaskController, app_han
                 &saf_folder_uri,
             )
             .await;
+            save_cover_art(
+                &app_handle,
+                is_saf,
+                &download_dir,
+                &saf_file_uri,
+                &ctx.song_info.cover_url,
+                &ctx.song_info.title,
+                &ctx.song_info.artist,
+                &ctx.song_info.album,
+            )
+            .await;
             let actual_quality =
                 crate::utils::quality::quality_label_from_filename(&actual_quality_filename);
             let requested_quality =
@@ -715,6 +727,17 @@ pub async fn download_task(ctx: TaskContext, controller: TaskController, app_han
                     is_saf,
                     &download_dir,
                     &saf_folder_uri,
+                )
+                .await;
+                save_cover_art(
+                    &app_handle,
+                    is_saf,
+                    &download_dir,
+                    &saf_file_uri,
+                    &ctx.song_info.cover_url,
+                    &ctx.song_info.title,
+                    &ctx.song_info.artist,
+                    &ctx.song_info.album,
                 )
                 .await;
                 let actual_quality =
@@ -934,4 +957,216 @@ fn write_saf_lrc(
             .map_err(|e| format!("写入 SAF 歌词失败: {}", e))?;
         Ok(())
     }
+}
+
+/// 下载封面图字节并嵌入音频标签。
+/// 普通模式与 SAF（Android）模式均支持：SAF 模式通过 SAF 文件 URI 打开为可读写
+/// 文件句柄，由 lofty 原地修改标签。
+async fn save_cover_art(
+    app_handle: &AppHandle,
+    is_saf: bool,
+    audio_path: &str,
+    saf_file_uri: &Option<String>,
+    cover_url: &str,
+    title: &str,
+    artist: &str,
+    album: &str,
+) {
+    if cover_url.is_empty() {
+        log::debug!("封面 URL 为空，跳过封面嵌入: {}", audio_path);
+        return;
+    }
+
+    let bytes = match fetch_cover_bytes(cover_url).await {
+        Ok(b) => b,
+        Err(e) => {
+            log::warn!("获取封面失败 {}: {}", cover_url, e);
+            return;
+        }
+    };
+    if bytes.is_empty() {
+        log::warn!("封面数据为空，跳过嵌入: {}", cover_url);
+        return;
+    }
+
+    let result = if is_saf {
+        embed_cover_art_saf(app_handle, saf_file_uri, &bytes, title, artist, album)
+    } else {
+        embed_cover_art_path(audio_path, &bytes, title, artist, album)
+    };
+
+    match result {
+        Ok(()) => log::info!("已嵌入封面与标签: {}", audio_path),
+        Err(e) => log::warn!("嵌入封面失败 {}: {}", audio_path, e),
+    }
+}
+
+/// 下载封面图片字节
+async fn fetch_cover_bytes(url: &str) -> Result<Vec<u8>, String> {
+    let resp = DOWNLOAD_CLIENT
+        .get(url)
+        .header("Referer", "https://y.qq.com")
+        .send()
+        .await
+        .map_err(|e| format!("请求失败: {}", e))?;
+    if !resp.status().is_success() {
+        return Err(format!("封面响应状态: {}", resp.status()));
+    }
+    let body = resp
+        .bytes()
+        .await
+        .map_err(|e| format!("读取封面失败: {}", e))?;
+    Ok(body.to_vec())
+}
+
+/// 普通模式：用文件路径读写标签
+fn embed_cover_art_path(
+    audio_path: &str,
+    cover_bytes: &[u8],
+    title: &str,
+    artist: &str,
+    album: &str,
+) -> Result<(), String> {
+    use lofty::config::WriteOptions;
+    use lofty::file::{AudioFile, TaggedFileExt};
+
+    let path = std::path::Path::new(audio_path);
+    let mut tagged_file = lofty::read_from_path(path)
+        .map_err(|e| format!("读取音频失败: {}", e))?;
+
+    ensure_primary_tag(&mut tagged_file);
+
+    let tag = tagged_file
+        .primary_tag_mut()
+        .ok_or_else(|| "无主标签可写".to_string())?;
+    set_tag_fields(tag, cover_bytes, title, artist, album);
+
+    tagged_file
+        .save_to_path(path, WriteOptions::default())
+        .map_err(|e| format!("保存标签失败: {}", e))?;
+    Ok(())
+}
+
+/// SAF（Android）模式：读取整个 SAF 文件字节，在内存中用 lofty 修改标签，
+/// 然后全量写回。避免 SAF 句柄 truncate 语义不确定的风险。
+#[cfg(target_os = "android")]
+fn embed_cover_art_saf(
+    app_handle: &AppHandle,
+    saf_file_uri: &Option<String>,
+    cover_bytes: &[u8],
+    title: &str,
+    artist: &str,
+    album: &str,
+) -> Result<(), String> {
+    use std::io::Cursor;
+
+    let uri_str = saf_file_uri
+        .as_ref()
+        .ok_or_else(|| "缺少 SAF 文件 URI".to_string())?;
+    let api = app_handle.android_fs();
+    let fs_uri = FsUri::from_uri(uri_str.clone());
+
+    // 读取整个文件到内存
+    let data = api
+        .read(&fs_uri)
+        .map_err(|e| format!("读取 SAF 文件失败: {}", e))?;
+    let mut cursor = Cursor::new(data);
+
+    let new_data = embed_cover_in_cursor(&mut cursor, cover_bytes, title, artist, album)?;
+    api.write(&fs_uri, &new_data)
+        .map_err(|e| format!("写回 SAF 文件失败: {}", e))?;
+    Ok(())
+}
+
+/// 在内存游标上完成封面嵌入，返回修改后的字节。桌面/Android 共用，便于桌面编译验证。
+#[allow(dead_code)]
+fn embed_cover_in_cursor(
+    cursor: &mut std::io::Cursor<Vec<u8>>,
+    cover_bytes: &[u8],
+    title: &str,
+    artist: &str,
+    album: &str,
+) -> Result<Vec<u8>, String> {
+    use lofty::config::WriteOptions;
+    use lofty::file::{AudioFile, TaggedFileExt};
+    use std::io::{Seek, SeekFrom};
+
+    let mut tagged_file = lofty::probe::Probe::new(&mut *cursor)
+        .guess_file_type()
+        .map_err(|e| format!("探测音频类型失败: {}", e))?
+        .read()
+        .map_err(|e| format!("读取音频失败: {}", e))?;
+    ensure_primary_tag(&mut tagged_file);
+
+    let tag = tagged_file
+        .primary_tag_mut()
+        .ok_or_else(|| "无主标签可写".to_string())?;
+    set_tag_fields(tag, cover_bytes, title, artist, album);
+
+    cursor
+        .seek(SeekFrom::Start(0))
+        .map_err(|e| format!("文件定位失败: {}", e))?;
+    tagged_file
+        .save_to(cursor, WriteOptions::default())
+        .map_err(|e| format!("保存标签失败: {}", e))?;
+
+    Ok(std::mem::take(cursor.get_mut()))
+}
+
+/// SAF 模式在非 Android 平台的占位实现（编译占位，运行时不会走到）
+#[cfg(not(target_os = "android"))]
+fn embed_cover_art_saf(
+    _app_handle: &AppHandle,
+    _saf_file_uri: &Option<String>,
+    _cover_bytes: &[u8],
+    _title: &str,
+    _artist: &str,
+    _album: &str,
+) -> Result<(), String> {
+    Err("SAF 模式仅在 Android 上可用".to_string())
+}
+
+/// 若不存在主标签，按文件类型创建并插入一个空标签
+fn ensure_primary_tag(tagged_file: &mut lofty::file::TaggedFile) {
+    use lofty::file::TaggedFileExt;
+    use lofty::tag::{Tag, TagType};
+    if tagged_file.primary_tag().is_some() {
+        return;
+    }
+    let tag_type = tagged_file.primary_tag_type();
+    if tag_type == TagType::Id3v2 {
+        tagged_file.insert_tag(Tag::new(TagType::Id3v2));
+    } else {
+        tagged_file.insert_tag(Tag::new(tag_type));
+    }
+}
+
+/// 写入文本字段与封面
+fn set_tag_fields(
+    tag: &mut lofty::tag::Tag,
+    cover_bytes: &[u8],
+    title: &str,
+    artist: &str,
+    album: &str,
+) {
+    use lofty::picture::{MimeType, Picture, PictureType};
+    use lofty::tag::Accessor;
+
+    if !title.is_empty() {
+        tag.set_title(title.to_string());
+    }
+    if !artist.is_empty() {
+        tag.set_artist(artist.to_string());
+    }
+    if !album.is_empty() {
+        tag.set_album(album.to_string());
+    }
+    tag.remove_picture_type(PictureType::CoverFront);
+    let pic = Picture::new_unchecked(
+        PictureType::CoverFront,
+        Some(MimeType::Jpeg),
+        None,
+        cover_bytes.to_vec(),
+    );
+    tag.push_picture(pic);
 }

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -4,6 +4,7 @@ pub const DOWNLOAD_PROGRESS: &str = "download-progress";
 pub const DOWNLOAD_COMPLETED: &str = "download-completed";
 pub const DOWNLOAD_ERROR: &str = "download-error";
 pub const DOWNLOAD_LINK_EXPIRED: &str = "download-link-expired";
+pub const DOWNLOAD_QUALITY_CHANGED: &str = "download-quality-changed";
 
 #[derive(Serialize, Clone)]
 pub struct DownloadProgressPayload {
@@ -18,6 +19,9 @@ pub struct DownloadCompletedPayload {
     pub task_id: String,
     pub final_path: String,
     pub saf_folder_uri: Option<String>,
+    pub quality: String,
+    pub filename: String,
+    pub requested_quality: Option<String>,
 }
 
 #[derive(Serialize, Clone)]
@@ -30,4 +34,12 @@ pub struct DownloadErrorPayload {
 pub struct DownloadLinkExpiredPayload {
     pub task_id: String,
     pub current_offset: u64,
+}
+
+#[derive(Serialize, Clone)]
+pub struct DownloadQualityChangedPayload {
+    pub task_id: String,
+    pub requested_quality: String,
+    pub actual_quality: String,
+    pub filename: String,
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -31,6 +31,7 @@ pub fn run() {
                 Err(_) => 3,
             };
             engine.set_concurrency(max_concurrent);
+            commands::settings::restore_session(app.handle());
             app.manage(engine.clone());
 
             let engine_clone = engine;
@@ -64,6 +65,7 @@ pub fn run() {
             commands::api::fetch_hot_keywords,
             commands::api::fetch_suggestions,
             commands::api::fetch_playlist_songs,
+            commands::api::fetch_lyrics,
             commands::api::check_update,
         ])
         .run(tauri::generate_context!())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -67,6 +67,8 @@ pub fn run() {
             commands::api::fetch_playlist_songs,
             commands::api::fetch_lyrics,
             commands::api::check_update,
+            commands::login::start_qq_login,
+            commands::login::capture_qq_login,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/utils/auth.rs
+++ b/src-tauri/src/utils/auth.rs
@@ -79,6 +79,25 @@ pub fn parse_qq_session(cookie: &str) -> Option<QqSession> {
     })
 }
 
+/// 把 Cookie 列表拼成 `k=v; k=v`，供请求头和设置保存使用。
+pub fn format_cookie_header(pairs: &[(String, String)]) -> String {
+    let mut seen = HashMap::new();
+    for (name, value) in pairs {
+        let key = name.trim();
+        if key.is_empty() {
+            continue;
+        }
+        seen.insert(key.to_string(), value.trim().to_string());
+    }
+    let mut names: Vec<String> = seen.keys().cloned().collect();
+    names.sort();
+    names
+        .into_iter()
+        .map(|name| format!("{}={}", name, seen[&name]))
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -111,5 +130,15 @@ mod tests {
     fn rejects_empty() {
         assert!(parse_qq_session("").is_none());
         assert!(parse_qq_session("   ").is_none());
+    }
+
+    #[test]
+    fn format_cookie_header_sorts_and_dedups() {
+        let header = format_cookie_header(&[
+            ("qm_keyst".into(), "abc".into()),
+            ("uin".into(), "o123".into()),
+            ("uin".into(), "o456".into()),
+        ]);
+        assert_eq!(header, "qm_keyst=abc; uin=o456");
     }
 }

--- a/src-tauri/src/utils/auth.rs
+++ b/src-tauri/src/utils/auth.rs
@@ -1,0 +1,115 @@
+/// QQ 音乐网页 Cookie 解析。
+/// 登录后浏览器里需要至少有 `uin`/`wxuin`，以及 `qm_keyst` 或 `qqmusic_key`。
+
+use once_cell::sync::Lazy;
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+static CURRENT_SESSION: Lazy<Mutex<Option<QqSession>>> = Lazy::new(|| Mutex::new(None));
+
+/// 用设置里的 Cookie 更新当前会话。空字符串或无效 Cookie 视为未登录。
+pub fn set_session_from_cookie(cookie: &str) {
+    let session = parse_qq_session(cookie);
+    if let Ok(mut guard) = CURRENT_SESSION.lock() {
+        *guard = session;
+    }
+}
+
+/// 当前已解析的登录会话。
+pub fn current_session() -> Option<QqSession> {
+    CURRENT_SESSION.lock().ok().and_then(|g| g.clone())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QqSession {
+    pub cookie: String,
+    pub uin: String,
+}
+
+fn parse_cookie_map(cookie: &str) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    for part in cookie.split(';') {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
+        let (key, value) = match part.split_once('=') {
+            Some((k, v)) => (k.trim(), v.trim()),
+            None => continue,
+        };
+        if key.is_empty() {
+            continue;
+        }
+        map.insert(key.to_ascii_lowercase(), value.to_string());
+    }
+    map
+}
+
+fn normalize_uin(raw: &str) -> Option<String> {
+    let trimmed = raw.trim().trim_start_matches(['o', 'O']);
+    if trimmed.is_empty() || trimmed == "0" {
+        return None;
+    }
+    if !trimmed.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    Some(trimmed.to_string())
+}
+
+/// 从 Cookie 字符串提取登录会话。缺少 uin 或登录票据时返回 None。
+pub fn parse_qq_session(cookie: &str) -> Option<QqSession> {
+    let cookie = cookie.trim();
+    if cookie.is_empty() {
+        return None;
+    }
+    let map = parse_cookie_map(cookie);
+    let uin = map
+        .get("uin")
+        .or_else(|| map.get("wxuin"))
+        .and_then(|v| normalize_uin(v))?;
+    let has_ticket = ["qm_keyst", "qqmusic_key", "psrf_qqaccess_token"]
+        .iter()
+        .any(|k| map.get(*k).map(|v| !v.is_empty()).unwrap_or(false));
+    if !has_ticket {
+        return None;
+    }
+    Some(QqSession {
+        cookie: cookie.to_string(),
+        uin,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_uin_and_qm_keyst() {
+        let session = parse_qq_session("uin=o123456789; qm_keyst=abc; other=1").expect("session");
+        assert_eq!(session.uin, "123456789");
+        assert!(session.cookie.contains("qm_keyst=abc"));
+    }
+
+    #[test]
+    fn accepts_wxuin_and_qqmusic_key() {
+        let session = parse_qq_session("wxuin=987654; qqmusic_key=xyz").expect("session");
+        assert_eq!(session.uin, "987654");
+    }
+
+    #[test]
+    fn rejects_missing_ticket() {
+        assert!(parse_qq_session("uin=o123456789").is_none());
+    }
+
+    #[test]
+    fn rejects_guest_uin() {
+        assert!(parse_qq_session("uin=o0; qm_keyst=abc").is_none());
+        assert!(parse_qq_session("uin=0; qm_keyst=abc").is_none());
+    }
+
+    #[test]
+    fn rejects_empty() {
+        assert!(parse_qq_session("").is_none());
+        assert!(parse_qq_session("   ").is_none());
+    }
+}

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -1,2 +1,4 @@
-pub mod filename;
+pub mod auth;
 pub mod crypto;
+pub mod filename;
+pub mod quality;

--- a/src-tauri/src/utils/quality.rs
+++ b/src-tauri/src/utils/quality.rs
@@ -1,0 +1,357 @@
+/// QQ 音乐品质文件名辅助：从品质文件名提取 media_mid，并在当前品质被拦截时给出**更低**音质回退。
+///
+/// 未登录时 `CgiGetVkey` 对 `.mp3` / `.m4a` / `.ape` 一律返回 104003。
+/// 加密容器 `.mflac` / `.mgg` 仍可通过 `GetEVkey` 下载。
+/// 回退只允许比请求音质更低的加密格式，禁止升到 flac。
+
+use std::path::Path;
+
+/// 标准品质：前缀、扩展名、从低到高的等级、是否加密容器。
+/// 等级与前端 `ALL_QUALITY_ORDER` 对齐。
+const STANDARD_QUALITIES: &[(&str, &str, u8, bool)] = &[
+    ("C200", ".m4a", 0, false),   // 48kacc
+    ("C400", ".m4a", 1, false),   // 96kacc
+    ("C600", ".m4a", 2, false),   // 192kacc
+    ("O4M0", ".mgg", 3, true),    // 96kogg
+    ("O6M0", ".mgg", 4, true),    // 192kogg
+    ("M500", ".mp3", 5, false),   // 128kmp3
+    ("M800", ".mp3", 6, false),   // 320kmp3
+    ("A000", ".ape", 7, false),   // ape
+    ("F0M0", ".mflac", 8, true),  // flac
+    ("RSM1", ".mflac", 9, true),  // hires
+];
+
+fn stem_of(filename: &str) -> Option<&str> {
+    Path::new(filename).file_stem()?.to_str()
+}
+
+fn prefix_of(filename: &str) -> Option<&str> {
+    let stem = stem_of(filename)?;
+    if stem.len() < 4 {
+        return None;
+    }
+    Some(&stem[..4])
+}
+
+fn spec_by_prefix(prefix: &str) -> Option<(&'static str, &'static str, u8, bool)> {
+    STANDARD_QUALITIES
+        .iter()
+        .copied()
+        .find(|(p, _, _, _)| *p == prefix)
+}
+
+/// 从品质文件名提取 media_mid。
+/// 文件名格式为 4 字符前缀 + media_mid + 扩展名，例如 `M800002dXBY24GGon8.mp3`。
+pub fn extract_media_mid(filename: &str) -> Option<&str> {
+    let stem = stem_of(filename)?;
+    if stem.len() <= 4 {
+        return None;
+    }
+    Some(&stem[4..])
+}
+
+fn extension_lower(filename: &str) -> String {
+    Path::new(filename)
+        .extension()
+        .and_then(|s| s.to_str())
+        .map(|s| s.to_lowercase())
+        .unwrap_or_default()
+}
+
+/// 已是加密容器，走 GetEVkey。
+pub fn is_encrypted_filename(filename: &str) -> bool {
+    matches!(extension_lower(filename).as_str(), "mgg" | "mflac")
+}
+
+const QUALITY_LABELS: &[(&str, &str)] = &[
+    ("C200", "48kacc"),
+    ("C400", "96kacc"),
+    ("C600", "192kacc"),
+    ("O4M0", "96kogg"),
+    ("O6M0", "192kogg"),
+    ("M500", "128kmp3"),
+    ("M800", "320kmp3"),
+    ("A000", "ape"),
+    ("F0M0", "flac"),
+    ("RSM1", "hires"),
+    ("Q0M0", "杜比全景声"),
+    ("Q0M1", "臻品全景声"),
+    ("AIM0", "臻品母带"),
+];
+
+/// 从品质文件名还原前端音质标签。无法识别时返回文件名本身。
+pub fn quality_label_from_filename(filename: &str) -> String {
+    prefix_of(filename)
+        .and_then(|prefix| {
+            QUALITY_LABELS
+                .iter()
+                .find(|(p, _)| *p == prefix)
+                .map(|(_, label)| (*label).to_string())
+        })
+        .unwrap_or_else(|| filename.to_string())
+}
+
+/// 当前品质被平台拦截时，按从高到低返回**更低**的加密文件名。
+/// 不会返回比请求更高的音质（例如 320kmp3 不会回退到 flac）。
+/// 特殊音质（杜比 / 臻品）的 mid 不是 media_mid，无法安全推导，返回空。
+pub fn lower_encrypted_fallbacks(filename: &str) -> Vec<String> {
+    let Some(prefix) = prefix_of(filename) else {
+        return Vec::new();
+    };
+    let Some((_, _, rank, _)) = spec_by_prefix(prefix) else {
+        return Vec::new();
+    };
+    let Some(media) = extract_media_mid(filename) else {
+        return Vec::new();
+    };
+
+    STANDARD_QUALITIES
+        .iter()
+        .rev()
+        .filter(|(_, _, cand_rank, encrypted)| *encrypted && *cand_rank < rank)
+        .map(|(cand_prefix, cand_ext, _, _)| format!("{}{}{}", cand_prefix, media, cand_ext))
+        .collect()
+}
+
+/// 是否属于「该音质当前拿不到链接」——应尝试更低音质，而不是当网络抖动重试。
+pub fn is_unavailable_link_error(err: &str) -> bool {
+    err.contains("无法获取下载链接")
+        || err.contains("104003")
+        || err.contains("已下架")
+        || err.contains("禁止下载")
+}
+
+/// 是否属于可重试的瞬时网络错误。
+pub fn is_retryable_link_error(err: &str) -> bool {
+    err.starts_with("网络错误") || err.starts_with("读取响应失败")
+}
+
+/// 一次取链尝试的结果。`filename` 是这次实际请求的品质文件名。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LinkAttempt {
+    Ok {
+        url: String,
+        key: String,
+        filename: String,
+    },
+    Err {
+        filename: String,
+        error: String,
+    },
+}
+
+/// 根据首选品质的结果，决定最终用哪条链接。
+/// 首选成功则原样返回；平台拒绝时按 `lower_encrypted_fallbacks` 顺序取第一条成功的回退。
+pub fn resolve_link_attempt(
+    requested: &str,
+    primary: LinkAttempt,
+    fallbacks: &[LinkAttempt],
+) -> Result<(String, String, String), String> {
+    match primary {
+        LinkAttempt::Ok { url, key, filename } => Ok((url, key, filename)),
+        LinkAttempt::Err { error, .. } if is_unavailable_link_error(&error) => {
+            if lower_encrypted_fallbacks(requested).is_empty() {
+                return Err(error);
+            }
+            let mut last_err = error;
+            for attempt in fallbacks {
+                match attempt {
+                    LinkAttempt::Ok { url, key, filename } => {
+                        return Ok((url.clone(), key.clone(), filename.clone()));
+                    }
+                    LinkAttempt::Err { error, .. } => last_err = error.clone(),
+                }
+            }
+            Err(last_err)
+        }
+        LinkAttempt::Err { error, .. } => Err(error),
+    }
+}
+
+/// 从歌词接口 JSON 中取出 LRC 文本。
+pub fn parse_lyric_json(text: &str) -> Result<String, String> {
+    let data: serde_json::Value =
+        serde_json::from_str(text).map_err(|e| format!("解析歌词失败: {}", e))?;
+    let code = data["code"].as_i64().unwrap_or(-1);
+    let retcode = data["retcode"].as_i64().unwrap_or(0);
+    if code != 0 && retcode != 0 {
+        return Err(format!("歌词接口错误: code={}, retcode={}", code, retcode));
+    }
+    let lyric = data["lyric"].as_str().unwrap_or("").trim().to_string();
+    if lyric.is_empty() {
+        return Err("暂无歌词".into());
+    }
+    Ok(lyric)
+}
+
+/// 音频文件对应的同名 `.lrc` 路径。
+pub fn sidecar_lrc_path(audio_path: &str) -> std::path::PathBuf {
+    Path::new(audio_path).with_extension("lrc")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_media_mid_from_standard_names() {
+        assert_eq!(
+            extract_media_mid("M800002dXBY24GGon8.mp3"),
+            Some("002dXBY24GGon8")
+        );
+        assert_eq!(
+            extract_media_mid("C200002dXBY24GGon8.m4a"),
+            Some("002dXBY24GGon8")
+        );
+        assert_eq!(
+            extract_media_mid("F0M0002dXBY24GGon8.mflac"),
+            Some("002dXBY24GGon8")
+        );
+    }
+
+    #[test]
+    fn extract_media_mid_rejects_short_names() {
+        assert_eq!(extract_media_mid("abc.mp3"), None);
+        assert_eq!(extract_media_mid(""), None);
+    }
+
+    #[test]
+    fn mp3_downgrades_to_lower_ogg_not_flac() {
+        assert_eq!(
+            lower_encrypted_fallbacks("M800002dXBY24GGon8.mp3"),
+            vec![
+                "O6M0002dXBY24GGon8.mgg".to_string(),
+                "O4M0002dXBY24GGon8.mgg".to_string(),
+            ]
+        );
+        assert_eq!(
+            lower_encrypted_fallbacks("M500002dXBY24GGon8.mp3"),
+            vec![
+                "O6M0002dXBY24GGon8.mgg".to_string(),
+                "O4M0002dXBY24GGon8.mgg".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn flac_downgrades_to_ogg_only() {
+        assert_eq!(
+            lower_encrypted_fallbacks("F0M0002dXBY24GGon8.mflac"),
+            vec![
+                "O6M0002dXBY24GGon8.mgg".to_string(),
+                "O4M0002dXBY24GGon8.mgg".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn lowest_encrypted_has_no_fallback() {
+        assert!(lower_encrypted_fallbacks("O4M0002dXBY24GGon8.mgg").is_empty());
+    }
+
+    #[test]
+    fn special_quality_cannot_derive_media_mid_fallbacks() {
+        // 臻品母带的 stem 不是 media_mid，不能拿去拼 F0M0/O6M0
+        assert!(lower_encrypted_fallbacks("AIM0notMediaMid.mflac").is_empty());
+    }
+
+    #[test]
+    fn unavailable_error_detects_platform_blocks() {
+        assert!(is_unavailable_link_error("无法获取下载链接"));
+        assert!(is_unavailable_link_error("获取下载链接失败，错误码: 104003"));
+        assert!(is_unavailable_link_error("该歌曲已下架或禁止下载"));
+        assert!(!is_unavailable_link_error("网络错误: timeout"));
+        assert!(!is_unavailable_link_error("解析响应失败"));
+    }
+
+    #[test]
+    fn retryable_error_only_matches_transport() {
+        assert!(is_retryable_link_error("网络错误: connection reset"));
+        assert!(is_retryable_link_error("读取响应失败: eof"));
+        assert!(!is_retryable_link_error("无法获取下载链接"));
+    }
+
+    #[test]
+    fn resolve_falls_back_from_blocked_mp3_to_lower_ogg() {
+        let requested = "M800002dXBY24GGon8.mp3";
+        let primary = LinkAttempt::Err {
+            filename: requested.to_string(),
+            error: "无法获取下载链接".to_string(),
+        };
+        let fallbacks = vec![LinkAttempt::Ok {
+            url: "https://wx.music.tc.qq.com/O6M0.mgg".to_string(),
+            key: "ekey".to_string(),
+            filename: "O6M0002dXBY24GGon8.mgg".to_string(),
+        }];
+        let (url, key, filename) =
+            resolve_link_attempt(requested, primary, &fallbacks).expect("should fallback");
+        assert!(url.ends_with(".mgg"));
+        assert_eq!(key, "ekey");
+        assert_eq!(filename, "O6M0002dXBY24GGon8.mgg");
+    }
+
+    #[test]
+    fn resolve_keeps_successful_primary() {
+        let requested = "M800002dXBY24GGon8.mp3";
+        let primary = LinkAttempt::Ok {
+            url: "https://cdn/M800.mp3".to_string(),
+            key: String::new(),
+            filename: requested.to_string(),
+        };
+        let (url, key, filename) =
+            resolve_link_attempt(requested, primary, &[]).expect("primary should win");
+        assert!(url.ends_with(".mp3"));
+        assert!(key.is_empty());
+        assert_eq!(filename, requested);
+    }
+
+    #[test]
+    fn resolve_does_not_fallback_on_network_error() {
+        let requested = "M800002dXBY24GGon8.mp3";
+        let primary = LinkAttempt::Err {
+            filename: requested.to_string(),
+            error: "网络错误: timeout".to_string(),
+        };
+        let fallbacks = vec![LinkAttempt::Ok {
+            url: "https://cdn/O6M0.mgg".to_string(),
+            key: "ekey".to_string(),
+            filename: "O6M0002dXBY24GGon8.mgg".to_string(),
+        }];
+        let err = resolve_link_attempt(requested, primary, &fallbacks).unwrap_err();
+        assert!(err.starts_with("网络错误"));
+    }
+
+    #[test]
+    fn parse_lyric_json_reads_lrc() {
+        let raw = r#"{"retcode":0,"code":0,"subcode":0,"lyric":"[ti:冻结]\n[ar:林俊杰]\n[00:00.00]冻结"}"#;
+        let lyric = parse_lyric_json(raw).expect("lyric");
+        assert!(lyric.contains("[ti:冻结]"));
+        assert!(lyric.contains("林俊杰"));
+    }
+
+    #[test]
+    fn parse_lyric_json_rejects_empty() {
+        let raw = r#"{"retcode":0,"code":0,"lyric":""}"#;
+        assert!(parse_lyric_json(raw).is_err());
+    }
+
+    #[test]
+    fn quality_label_from_common_filenames() {
+        assert_eq!(quality_label_from_filename("M800002dXBY24GGon8.mp3"), "320kmp3");
+        assert_eq!(quality_label_from_filename("O6M0002dXBY24GGon8.mgg"), "192kogg");
+        assert_eq!(quality_label_from_filename("O4M0002dXBY24GGon8.mgg"), "96kogg");
+        assert_eq!(quality_label_from_filename("F0M0002dXBY24GGon8.mflac"), "flac");
+    }
+
+    #[test]
+    fn sidecar_lrc_replaces_extension() {
+        assert_eq!(
+            sidecar_lrc_path(r"D:\Music\冻结 - 林俊杰.mp3"),
+            Path::new(r"D:\Music\冻结 - 林俊杰.lrc")
+        );
+        assert_eq!(
+            sidecar_lrc_path(r"D:\Music\冻结 - 林俊杰.ogg"),
+            Path::new(r"D:\Music\冻结 - 林俊杰.lrc")
+        );
+    }
+}

--- a/src/components/settings/LyricSetting.vue
+++ b/src/components/settings/LyricSetting.vue
@@ -1,0 +1,59 @@
+<template>
+    <template v-if="isNarrow">
+        <div class="setting-row">
+            <span class="setting-label">下载歌词</span>
+            <n-switch :value="settingsStore.settings.downloadLyrics"
+                @update:value="(val) => (settingsStore.settings.downloadLyrics = val)" />
+        </div>
+    </template>
+    <template v-else>
+        <n-form-item label="下载歌词">
+            <n-switch :value="settingsStore.settings.downloadLyrics"
+                @update:value="(val) => (settingsStore.settings.downloadLyrics = val)" />
+        </n-form-item>
+    </template>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted } from 'vue'
+import { NFormItem, NSwitch } from 'naive-ui'
+import { useSettingsStore } from '../../stores/settingsStore'
+
+const settingsStore = useSettingsStore()
+
+const isNarrow = ref(
+    typeof window !== 'undefined' &&
+    window.matchMedia('(max-width: 767px)').matches
+)
+let mediaQuery: MediaQueryList | null = null
+
+function updateNarrow(e: MediaQueryListEvent | MediaQueryList) {
+    isNarrow.value = e.matches
+}
+
+onMounted(() => {
+    mediaQuery = window.matchMedia('(max-width: 767px)')
+    updateNarrow(mediaQuery)
+    mediaQuery.addEventListener('change', updateNarrow)
+})
+
+onUnmounted(() => {
+    if (mediaQuery) {
+        mediaQuery.removeEventListener('change', updateNarrow)
+    }
+})
+</script>
+
+<style scoped>
+.setting-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 16px;
+}
+
+.setting-label {
+    font-size: 14px;
+    color: var(--n-text-color);
+}
+</style>

--- a/src/components/settings/SourceSetting.vue
+++ b/src/components/settings/SourceSetting.vue
@@ -1,28 +1,47 @@
 <template>
-    <n-form-item label="QQ 音乐 Cookie">
-        <n-input type="textarea" :value="settingsStore.settings.qqCookie"
-            @update:value="(val) => (settingsStore.settings.qqCookie = val)" :autosize="{ minRows: 3, maxRows: 6 }"
-            placeholder="从 y.qq.com 复制 Cookie，需包含 uin 与 qm_keyst" />
-        <template #feedback>
+    <n-form-item label="QQ 音乐登录">
+        <div class="source-login">
+            <div class="source-actions">
+                <n-button type="primary" :loading="loggingIn" @click="handleLogin">
+                    {{ isLoggedIn ? '重新登录' : '登录 QQ 音乐' }}
+                </n-button>
+                <n-button v-if="loggingIn" @click="handleCapture">我已登录，立即获取</n-button>
+                <n-button v-if="isLoggedIn" @click="handleLogout">退出登录</n-button>
+                <n-button text @click="showManual = !showManual">
+                    {{ showManual ? '收起手动填写' : '手动粘贴 Cookie' }}
+                </n-button>
+            </div>
             <div class="source-help">
                 <div>登录状态：{{ loginStatus }}</div>
                 <div>
-                    在浏览器打开
-                    <n-a href="https://y.qq.com" target="_blank">y.qq.com</n-a>
-                    并登录后，打开开发者工具 → Network，复制任意请求的 Cookie。
-                    填入后即可尝试 320kmp3 等需登录音质。未登录时只能下载未加密的较低音质。
+                    点击登录后会打开 QQ 音乐网页，用你平时的方式登录即可。
+                    登录成功后会自动保存，无需自己复制 Cookie。
                 </div>
             </div>
-        </template>
+            <n-input v-if="showManual" type="textarea" :value="settingsStore.settings.qqCookie"
+                @update:value="(val) => (settingsStore.settings.qqCookie = val)"
+                :autosize="{ minRows: 3, maxRows: 6 }"
+                placeholder="一般不用填。只有自动登录失败时，再从浏览器复制 Cookie。" />
+        </div>
     </n-form-item>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
-import { NFormItem, NInput, NA } from 'naive-ui'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { invoke } from '@tauri-apps/api/core'
+import { listen, type UnlistenFn } from '@tauri-apps/api/event'
+import { NFormItem, NInput, NButton } from 'naive-ui'
 import { useSettingsStore } from '../../stores/settingsStore'
 
+interface QqLoginCaptured {
+    cookie: string
+    uin: string
+}
+
 const settingsStore = useSettingsStore()
+const loggingIn = ref(false)
+const showManual = ref(false)
+let unlisten: UnlistenFn | null = null
 
 function parseCookieMap(cookie: string): Record<string, string> {
     const map: Record<string, string> = {}
@@ -42,22 +61,99 @@ function normalizeUin(raw?: string): string | null {
     return trimmed
 }
 
-const loginStatus = computed(() => {
+const detectedUin = computed(() => {
     const cookie = settingsStore.settings.qqCookie?.trim() ?? ''
-    if (!cookie) return '未登录（游客，无法获取 320kmp3）'
+    if (!cookie) return null
     const map = parseCookieMap(cookie)
     const uin = normalizeUin(map.uin) || normalizeUin(map.wxuin)
     const hasTicket = Boolean(map.qm_keyst || map.qqmusic_key || map.psrf_qqaccess_token)
-    if (uin && hasTicket) return `已识别账号 ${uin}`
-    return 'Cookie 不完整，请确认包含 uin 与 qm_keyst'
+    return uin && hasTicket ? uin : null
+})
+
+const isLoggedIn = computed(() => Boolean(detectedUin.value))
+
+const loginStatus = computed(() => {
+    if (loggingIn.value) return '请在弹出的窗口中登录 QQ 音乐'
+    if (detectedUin.value) return `已登录账号 ${detectedUin.value}`
+    const cookie = settingsStore.settings.qqCookie?.trim() ?? ''
+    if (cookie) return 'Cookie 不完整，请重新登录'
+    return '未登录（游客无法获取 320kmp3）'
+})
+
+function applyCaptured(captured: QqLoginCaptured) {
+    settingsStore.settings.qqCookie = captured.cookie
+    loggingIn.value = false
+}
+
+function notifyError(message: string) {
+    if (typeof window !== 'undefined' && (window as any).$notify) {
+        (window as any).$notify.error({ title: '登录失败', description: message, duration: 4000 })
+    }
+}
+
+function notifySuccess(uin: string) {
+    if (typeof window !== 'undefined' && (window as any).$notify) {
+        (window as any).$notify.success({ title: '登录成功', description: `已登录 QQ 音乐账号 ${uin}`, duration: 3000 })
+    }
+}
+
+async function handleLogin() {
+    loggingIn.value = true
+    try {
+        await invoke('start_qq_login')
+    } catch (e: any) {
+        loggingIn.value = false
+        notifyError(e?.message || String(e) || '打开登录窗口失败')
+    }
+}
+
+async function handleCapture() {
+    try {
+        const captured = await invoke<QqLoginCaptured>('capture_qq_login')
+        applyCaptured(captured)
+        notifySuccess(captured.uin)
+    } catch (e: any) {
+        notifyError(e?.message || String(e) || '尚未检测到登录')
+    }
+}
+
+function handleLogout() {
+    settingsStore.settings.qqCookie = ''
+    loggingIn.value = false
+}
+
+onMounted(async () => {
+    unlisten = await listen<QqLoginCaptured>('qq-login-success', (event) => {
+        applyCaptured(event.payload)
+        notifySuccess(event.payload.uin)
+    })
+})
+
+onUnmounted(() => {
+    if (unlisten) {
+        unlisten()
+        unlisten = null
+    }
 })
 </script>
 
 <style scoped>
+.source-login {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.source-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
 .source-help {
     font-size: 12px;
     color: var(--n-text-color-3);
-    margin-top: 4px;
     line-height: 1.6;
 }
 </style>

--- a/src/components/settings/SourceSetting.vue
+++ b/src/components/settings/SourceSetting.vue
@@ -1,0 +1,63 @@
+<template>
+    <n-form-item label="QQ 音乐 Cookie">
+        <n-input type="textarea" :value="settingsStore.settings.qqCookie"
+            @update:value="(val) => (settingsStore.settings.qqCookie = val)" :autosize="{ minRows: 3, maxRows: 6 }"
+            placeholder="从 y.qq.com 复制 Cookie，需包含 uin 与 qm_keyst" />
+        <template #feedback>
+            <div class="source-help">
+                <div>登录状态：{{ loginStatus }}</div>
+                <div>
+                    在浏览器打开
+                    <n-a href="https://y.qq.com" target="_blank">y.qq.com</n-a>
+                    并登录后，打开开发者工具 → Network，复制任意请求的 Cookie。
+                    填入后即可尝试 320kmp3 等需登录音质。未登录时只能下载未加密的较低音质。
+                </div>
+            </div>
+        </template>
+    </n-form-item>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { NFormItem, NInput, NA } from 'naive-ui'
+import { useSettingsStore } from '../../stores/settingsStore'
+
+const settingsStore = useSettingsStore()
+
+function parseCookieMap(cookie: string): Record<string, string> {
+    const map: Record<string, string> = {}
+    for (const part of cookie.split(';')) {
+        const [rawKey, ...rest] = part.split('=')
+        const key = rawKey?.trim().toLowerCase()
+        if (!key) continue
+        map[key] = rest.join('=').trim()
+    }
+    return map
+}
+
+function normalizeUin(raw?: string): string | null {
+    if (!raw) return null
+    const trimmed = raw.trim().replace(/^[oO]/, '')
+    if (!trimmed || trimmed === '0' || !/^\d+$/.test(trimmed)) return null
+    return trimmed
+}
+
+const loginStatus = computed(() => {
+    const cookie = settingsStore.settings.qqCookie?.trim() ?? ''
+    if (!cookie) return '未登录（游客，无法获取 320kmp3）'
+    const map = parseCookieMap(cookie)
+    const uin = normalizeUin(map.uin) || normalizeUin(map.wxuin)
+    const hasTicket = Boolean(map.qm_keyst || map.qqmusic_key || map.psrf_qqaccess_token)
+    if (uin && hasTicket) return `已识别账号 ${uin}`
+    return 'Cookie 不完整，请确认包含 uin 与 qm_keyst'
+})
+</script>
+
+<style scoped>
+.source-help {
+    font-size: 12px;
+    color: var(--n-text-color-3);
+    margin-top: 4px;
+    line-height: 1.6;
+}
+</style>

--- a/src/composables/useDownloadActions.ts
+++ b/src/composables/useDownloadActions.ts
@@ -115,6 +115,16 @@ export function useDownloadActions() {
                 return
             }
 
+            // 同一歌曲同一音质已有未清理任务时跳过，避免重复下载
+            if (taskStore.findDuplicate(song.id, resolved.quality)) {
+                notification.info({
+                    title: '已存在下载任务',
+                    description: `歌曲“${song.title}”的“${resolved.quality}”音质已在任务列表中`,
+                    duration: 3000,
+                })
+                return
+            }
+
             const taskId = generateTaskId()
             taskStore.addTask({
                 id: taskId,
@@ -191,6 +201,7 @@ export function useDownloadActions() {
             }
 
             let errorCount = 0
+            let skippedCount = 0
             for (const song of songs) {
                 const resolved = resolveQualityForSong(song, quality)
                 if (!resolved) {
@@ -216,6 +227,12 @@ export function useDownloadActions() {
                     continue
                 }
 
+                // 同一歌曲同一音质已有未清理任务时跳过
+                if (taskStore.findDuplicate(song.id, resolved.quality)) {
+                    skippedCount++
+                    continue
+                }
+
                 const taskId = generateTaskId()
                 taskStore.addTask({
                     id: taskId,
@@ -237,6 +254,10 @@ export function useDownloadActions() {
 
             if (errorCount > 0) {
                 notification.warning({ title: '批量下载', description: `${errorCount} 首歌曲无可用音质，已标记为错误` })
+            }
+
+            if (skippedCount > 0) {
+                notification.info({ title: '批量下载', description: `${skippedCount} 首歌曲已存在相同音质的任务，已跳过`, duration: 3000 })
             }
 
             if (settingsStore.settings.jumpToTask) {

--- a/src/stores/taskStore.ts
+++ b/src/stores/taskStore.ts
@@ -58,6 +58,22 @@ export const useTaskStore = defineStore('tasks', () => {
         }
     }
 
+    /**
+     * 检查同一首歌曲的同一音质是否已存在未清理的任务。
+     * 命中返回已存在任务的状态，未命中返回 null。
+     * 注意：降级会把 task.quality 改为实际品质，因此匹配的是 task.quality（实际）而非期望品质。
+     */
+    function findDuplicate(songId: string, quality: string): TaskRecord | null {
+        return (
+            tasks.value.find(
+                (t) =>
+                    t.songId === songId &&
+                    t.quality === quality &&
+                    t.status !== 'error'
+            ) ?? null
+        )
+    }
+
     // ---- 任务操作 ----
     function addTask(task: TaskRecord) {
         tasks.value.push(task)
@@ -74,6 +90,7 @@ export const useTaskStore = defineStore('tasks', () => {
             songTitle: task.songTitle,
             artist: task.artist,
             album: task.album,
+            coverUrl: task.coverUrl,
         }).catch((e: any) => {
             console.error('添加任务失败:', e)
             notify()?.error({ title: '添加任务失败', description: e?.message || String(e), duration: 3000 })
@@ -314,5 +331,6 @@ export const useTaskStore = defineStore('tasks', () => {
         retryTask,
         errorTask,
         setupListeners,
+        findDuplicate,
     }
 })

--- a/src/stores/taskStore.ts
+++ b/src/stores/taskStore.ts
@@ -8,8 +8,9 @@ import type {
     DownloadCompletedPayload,
     DownloadErrorPayload,
     DownloadLinkExpiredPayload,
+    DownloadQualityChangedPayload,
 } from '../types'
-import { QUALITY_DOWNGRADE_ORDER } from '../types'
+import { QUALITY_DOWNGRADE_ORDER, buildQualityFilename, extractMediaMid } from '../types'
 import { useSettingsStore } from './settingsStore'
 
 export const useTaskStore = defineStore('tasks', () => {
@@ -162,7 +163,16 @@ export const useTaskStore = defineStore('tasks', () => {
             if (settingsStore.settings.autoDowngrade) {
                 const currentIdx = QUALITY_DOWNGRADE_ORDER.indexOf(task.quality)
                 if (currentIdx >= 0 && currentIdx < QUALITY_DOWNGRADE_ORDER.length - 1) {
-                    task.quality = QUALITY_DOWNGRADE_ORDER[currentIdx + 1]
+                    const nextQuality = QUALITY_DOWNGRADE_ORDER[currentIdx + 1]
+                    const mediaMid = task.mediaMid || extractMediaMid(task.filename) || ''
+                    const nextFilename = buildQualityFilename(nextQuality, mediaMid)
+                    if (!nextFilename) {
+                        task.errorMsg = `无法降级至 ${nextQuality}：缺少对应文件名`
+                        await saveTasks()
+                        return false
+                    }
+                    task.quality = nextQuality
+                    task.filename = nextFilename
                     task.retryCount = 0
                     task.errorMsg = `自动降级至 ${task.quality}`
                     task.downloaded = 0 // 文件不同，必须重新下载
@@ -228,13 +238,36 @@ export const useTaskStore = defineStore('tasks', () => {
             // SAF 模式下 final_path 已经是完整 URI，无需额外处理
             task.filePath = event.payload.final_path
             task.downloaded = task.fileSize
+            if (event.payload.quality) {
+                task.quality = event.payload.quality
+            }
+            if (event.payload.filename) {
+                task.filename = event.payload.filename
+            }
 
             saveTasks()
-            // 成功通知
+            const requested = event.payload.requested_quality
+            const actual = event.payload.quality || task.quality
+            const downgraded = Boolean(requested && actual && requested !== actual)
             notify()?.success({
                 title: '下载完成',
-                description: `歌曲“${task.songTitle}”已下载完成`,
-                duration: 3000
+                description: downgraded
+                    ? `歌曲“${task.songTitle}”${requested} 暂无资源，已降级为 ${actual}`
+                    : `歌曲“${task.songTitle}”已下载完成（${actual}）`,
+                duration: 4000
+            })
+        })
+
+        listen<DownloadQualityChangedPayload>('download-quality-changed', (event) => {
+            const task = tasks.value.find((t) => t.id === event.payload.task_id)
+            if (!task) return
+            task.quality = event.payload.actual_quality
+            task.filename = event.payload.filename
+            saveTasks()
+            notify()?.warning({
+                title: '音质已降级',
+                description: `歌曲“${task.songTitle}”${event.payload.requested_quality} 暂无资源，已降级为 ${event.payload.actual_quality}`,
+                duration: 4000
             })
         })
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -18,6 +18,35 @@ export const ALL_QUALITY_ORDER: string[] = [
 /** 降级顺序：从高到低 */
 export const QUALITY_DOWNGRADE_ORDER: string[] = [...ALL_QUALITY_ORDER].reverse()
 
+/** 品质标签对应的文件名前缀与扩展名，与后端 build_qualities 保持一致 */
+export const QUALITY_FILE_SPEC: Record<string, { prefix: string; ext: string }> = {
+    '48kacc': { prefix: 'C200', ext: '.m4a' },
+    '96kacc': { prefix: 'C400', ext: '.m4a' },
+    '192kacc': { prefix: 'C600', ext: '.m4a' },
+    '96kogg': { prefix: 'O4M0', ext: '.mgg' },
+    '192kogg': { prefix: 'O6M0', ext: '.mgg' },
+    '128kmp3': { prefix: 'M500', ext: '.mp3' },
+    '320kmp3': { prefix: 'M800', ext: '.mp3' },
+    ape: { prefix: 'A000', ext: '.ape' },
+    flac: { prefix: 'F0M0', ext: '.mflac' },
+    hires: { prefix: 'RSM1', ext: '.mflac' },
+}
+
+/** 从品质文件名提取 media_mid（4 字符前缀 + mid + 扩展名） */
+export function extractMediaMid(filename: string): string | null {
+    const dot = filename.lastIndexOf('.')
+    const stem = dot >= 0 ? filename.slice(0, dot) : filename
+    if (stem.length <= 4) return null
+    return stem.slice(4)
+}
+
+/** 按品质标签重建文件名；特殊音质（杜比/臻品）无法从 mediaMid 推导，返回 null */
+export function buildQualityFilename(quality: string, mediaMid: string): string | null {
+    const spec = QUALITY_FILE_SPEC[quality]
+    if (!spec || !mediaMid) return null
+    return `${spec.prefix}${mediaMid}${spec.ext}`
+}
+
 export type Quality = string  // 不再限制字面量，兼容所有后端标签
 
 export type TaskStatus = 'waiting' | 'downloading' | 'paused' | 'completed' | 'error'
@@ -29,6 +58,10 @@ export interface Settings {
     namingTemplate: string
     maxConcurrent: number
     jumpToTask: boolean
+    /** 下载完成后写入同名 .lrc */
+    downloadLyrics: boolean
+    /** QQ 音乐网页 Cookie，用于解锁 320kmp3 等需登录音质 */
+    qqCookie: string
     // 新增 SAF 文件夹 URI 和名称
     safFolderUri?: string
     safFolderName?: string
@@ -124,6 +157,16 @@ export interface DownloadCompletedPayload {
     task_id: string
     final_path: string
     saf_folder_uri?: string | null
+    quality?: string
+    filename?: string
+    requested_quality?: string | null
+}
+
+export interface DownloadQualityChangedPayload {
+    task_id: string
+    requested_quality: string
+    actual_quality: string
+    filename: string
 }
 
 export interface DownloadErrorPayload {
@@ -143,6 +186,8 @@ export const DEFAULT_SETTINGS: Settings = {
     namingTemplate: '{song} - {artist}',
     maxConcurrent: 3,
     jumpToTask: true,
+    downloadLyrics: true,
+    qqCookie: '',
 }
 
 // GitHub 最新 release 信息

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -18,6 +18,14 @@
                     <NamingTemplate />
                     <ConcurrencySetting />
                     <JumpToTaskSetting />
+                    <LyricSetting />
+                </n-form>
+            </div>
+
+            <div class="settings-section">
+                <h2 class="section-title">音源管理</h2>
+                <n-form label-placement="top">
+                    <SourceSetting />
                 </n-form>
             </div>
         </template>
@@ -31,6 +39,8 @@
                 <NamingTemplate />
                 <ConcurrencySetting />
                 <JumpToTaskSetting />
+                <LyricSetting />
+                <SourceSetting />
                 <ClearHistoryButton />
             </n-form>
         </template>
@@ -88,6 +98,8 @@ import DirectorySetting from '../components/settings/DirectorySetting.vue'
 import NamingTemplate from '../components/settings/NamingTemplate.vue'
 import ConcurrencySetting from '../components/settings/ConcurrencySetting.vue'
 import JumpToTaskSetting from '../components/settings/JumpToTaskSetting.vue'
+import LyricSetting from '../components/settings/LyricSetting.vue'
+import SourceSetting from '../components/settings/SourceSetting.vue'
 import ClearHistoryButton from '../components/settings/ClearHistoryButton.vue'
 import * as musicApi from '../api/musicApi'
 import type { UpdateInfo } from '../types'


### PR DESCRIPTION
## 背景

未登录时 QQ 音乐 `CgiGetVkey` 对 `320kmp3` / `m4a` 固定返回 `104003`。此前会把真实错误盖成「网络错误」，自动回退还升到了 flac。

## 改动

- 设置新增「音源管理」，可填写 QQ 音乐网页 Cookie（`uin` + `qm_keyst`）解锁需登录音质
- 拿不到链接时只向更低加密音质降级（`320kmp3` → `192kogg` / `96kogg`），不再升到 flac
- 下载完成后写入同名 `.lrc`（设置可关，默认开）
- 降级时弹出「320kmp3 暂无资源，已降级为 xxx」，任务列表同步显示实际音质
- 非网络错误不再伪装成网络错误

## 验证

- `cargo test --lib`：Cookie 解析、品质回退、歌词解析共 19 项通过
- `vue-tsc -b` 通过
- 复现脚本 `scripts/repro-download-link.py` 确认未登录时 `M800` 被拦、加密音质可下