### PR TITLE
fix: 取链失败时展示真实原因，不再一律当成网络错误

### DIFF
--- a/src-tauri/src/commands/api.rs
+++ b/src-tauri/src/commands/api.rs
@@ -286,6 +286,22 @@ fn build_qualities(file: &Value, vs: &Value) -> Vec<Value> {
     list
 }
 
+fn plain_link_error(result_code: i64, tips: &str) -> String {
+    match result_code {
+        104003 => "无法获取该音质的下载链接（可能需要登录，或该歌曲暂无此音质）".to_string(),
+        104004 => "该歌曲已下架或禁止下载".to_string(),
+        0 => "无法获取该音质的下载链接".to_string(),
+        _ => {
+            let tips = tips.trim();
+            if tips.is_empty() {
+                format!("获取下载链接失败，错误码: {}", result_code)
+            } else {
+                format!("获取下载链接失败，错误码: {}，{}", result_code, tips)
+            }
+        }
+    }
+}
+
 /// 加密文件（.mgg / .mflac）专用，同时获取 purl 和 ekey
 /// https://github.com/chrisdong/FileHub/blob/e1d752e1f29f877b7c895ae5aaff32a179fad051/root/importURLs/lxmusic/HeiMusic%E8%81%9A%E5%90%88%E6%BA%90_v1.1.5.js#L287
 async fn fetch_encrypted_link(song_mid: &str, filename: &str) -> Result<(String, String), String> {
@@ -344,12 +360,7 @@ async fn fetch_encrypted_link(song_mid: &str, filename: &str) -> Result<(String,
     // 检查是否有错误标记
     let result_code = item["result"].as_i64().unwrap_or(0);
     if purl.is_empty() || result_code != 0 {
-        let err_msg = if result_code == 104003 {
-            "无法获取下载链接".to_string()
-        } else {
-            format!("获取下载链接失败，错误码: {}", result_code).to_string()
-        };
-        return Err(err_msg);
+        return Err(plain_link_error(result_code, ""));
     }
 
     // 提取 ekey
@@ -426,16 +437,10 @@ async fn fetch_plain_link(song_mid: &str, filename: &str) -> Result<(String, Str
 
     // 检查 purl 是否为空或 result 是否非0
     if purl.is_empty() || result_code != 0 {
-        let err_msg = match result_code {
-            104003 => "无法获取下载链接".to_string(),
-            104004 => "该歌曲已下架或禁止下载".to_string(),
-            _ => format!(
-                "获取下载链接失败，错误码: {}，详情: {:?}",
-                result_code,
-                item["tips"].as_str().unwrap_or("")
-            ),
-        };
-        return Err(err_msg);
+        return Err(plain_link_error(
+            result_code,
+            item["tips"].as_str().unwrap_or(""),
+        ));
     }
 
     let full_url = format!("https://wx.music.tc.qq.com/{}", purl);
@@ -811,4 +816,31 @@ pub async fn check_update() -> Result<String, String> {
     });
 
     Ok(serde_json::to_string(&result).map_err(|e| format!("序列化结果失败: {}", e))?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::plain_link_error;
+
+    #[test]
+    fn maps_platform_block_codes() {
+        assert_eq!(
+            plain_link_error(104003, ""),
+            "无法获取该音质的下载链接（可能需要登录，或该歌曲暂无此音质）"
+        );
+        assert_eq!(plain_link_error(104004, ""), "该歌曲已下架或禁止下载");
+        assert_eq!(plain_link_error(0, ""), "无法获取该音质的下载链接");
+    }
+
+    #[test]
+    fn keeps_unknown_code_and_optional_tips() {
+        assert_eq!(
+            plain_link_error(12345, ""),
+            "获取下载链接失败，错误码: 12345"
+        );
+        assert_eq!(
+            plain_link_error(12345, "  版权限制  "),
+            "获取下载链接失败，错误码: 12345，版权限制"
+        );
+    }
 }

--- a/src-tauri/src/download/task.rs
+++ b/src-tauri/src/download/task.rs
@@ -67,7 +67,7 @@ pub struct TaskContext {
     pub final_path: Arc<Mutex<Option<String>>>, // 与控制器共享的文件路径
 }
 
-/// 重试获取下载链接（网络错误时最多尝试 3 次）
+/// 重试获取下载链接（仅网络错误最多尝试 3 次，平台拒绝立即返回）
 async fn fetch_download_link_with_retry(
     song_mid: &str,
     filename: &str,
@@ -85,9 +85,14 @@ async fn fetch_download_link_with_retry(
                     attempt + 1,
                     last_err
                 );
+                if crate::utils::link_error::is_unavailable_link_error(&last_err) {
+                    return Err(last_err);
+                }
+                if !crate::utils::link_error::is_retryable_link_error(&last_err) {
+                    return Err(last_err);
+                }
                 if attempt < 2 {
                     tokio::time::sleep(Duration::from_secs(1 << attempt)).await;
-                    // 1s, 2s, 4s
                 }
             }
         }
@@ -395,7 +400,7 @@ pub async fn download_task(ctx: TaskContext, controller: TaskController, app_han
                 }
                 Err(e) => {
                     log::error!("任务 {} 最终获取下载链接失败: {}", ctx.task_id, e);
-                    progress::emit_error(&app_handle, &ctx.task_id, "网络错误，请稍后重试");
+                    progress::emit_error(&app_handle, &ctx.task_id, &e);
                     break 'download;
                 }
             }

--- a/src-tauri/src/utils/link_error.rs
+++ b/src-tauri/src/utils/link_error.rs
@@ -1,0 +1,45 @@
+/// 取链错误分类：区分「平台拒绝」和「瞬时网络抖动」。
+///
+/// `CgiGetVkey` 对未登录 / 无版权音质返回 104003，对下架歌曲返回 104004。
+/// 这两类再试也拿不到链接，不应当成网络错误重试，也不应盖成「网络错误，请稍后重试」。
+
+/// 该音质当前拿不到链接，应立刻把原因交给前端。
+pub fn is_unavailable_link_error(err: &str) -> bool {
+    (err.contains("无法获取") && err.contains("下载链接"))
+        || err.contains("104003")
+        || err.contains("已下架")
+        || err.contains("禁止下载")
+}
+
+/// 可重试的瞬时网络错误。
+pub fn is_retryable_link_error(err: &str) -> bool {
+    err.starts_with("网络错误") || err.starts_with("读取响应失败")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn platform_blocks_are_unavailable() {
+        assert!(is_unavailable_link_error(
+            "无法获取该音质的下载链接（可能需要登录，或该歌曲暂无此音质）"
+        ));
+        assert!(is_unavailable_link_error("该歌曲已下架或禁止下载"));
+        assert!(is_unavailable_link_error(
+            "获取下载链接失败，错误码: 104003"
+        ));
+        assert!(!is_unavailable_link_error("网络错误: timeout"));
+    }
+
+    #[test]
+    fn only_network_errors_are_retryable() {
+        assert!(is_retryable_link_error("网络错误: timeout"));
+        assert!(is_retryable_link_error("读取响应失败: eof"));
+        assert!(!is_retryable_link_error(
+            "无法获取该音质的下载链接（可能需要登录，或该歌曲暂无此音质）"
+        ));
+        assert!(!is_retryable_link_error("该歌曲已下架或禁止下载"));
+        assert!(!is_retryable_link_error("接口错误: code=1"));
+    }
+}

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -1,3 +1,4 @@
 pub mod crypto;
 pub mod filename;
+pub mod link_error;
 pub mod qrc;


### PR DESCRIPTION
## 描述

未登录或无版权时，QQ 取链会返回 104003/104004。原先下载任务会把这类错误连着重试 3 次，最后一律显示「网络错误，请稍后重试」。

这次只改提示和重试策略：

- 104003 →「无法获取该音质的下载链接（可能需要登录，或该歌曲暂无此音质）」
- 104004 →「该歌曲已下架或禁止下载」
- 平台拒绝立即返回，只有「网络错误 / 读取响应失败」才重试
- 任务列表和通知直接展示上述文案

没有接第三方音源，也没有改登录或音质回退。

## 关联 Issue

Related to #4

## 改动类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] 文档更新
- [ ] 其他

## 测试

- [x] 已添加或更新测试
- [ ] 已手动测试通过

`cargo test --lib`：新增 4 个单测通过（错误码映射 + 是否可重试）。

## 检查清单

- [x] 代码风格符合项目规范
- [x] 未引入新的依赖，或已说明原因
- [x] 未修改无关文件